### PR TITLE
feature: add new 'dirs' command to display important directories

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -91,7 +91,7 @@ fn command_dirs(_cli: &Cli) -> color_eyre::Result<()> {
 
     println!("bulletty directories");
     println!("\t-> Library: {}", library_path.to_string_lossy());
-    println!("\t-> Logs: {}", logs_path.to_string_lossy());
+    println!("\t-> Logs:    {}", logs_path.to_string_lossy());
 
     Ok(())
 }


### PR DESCRIPTION
### create `dirs` CLI command to display all the user directories  (#56)

**Updates**: The `Commands` enum will now include a `Dirs` field, which will be triggered when the user executes the _`bulletty dirs`_ command. This will result in a call to the `command_dirs()` function, which will print the paths for the _Library_ and _Logs_ directories for **bulletty**.

#### Preview
<img width="863" height="640" alt="Screenshot From 2025-10-06 23-59-00" src="https://github.com/user-attachments/assets/bfed1f3c-4007-4679-bf78-bbf9bc40885e" />

---

I hope this PR will enhance the functionality of **bulletty**.