### PR TITLE
feature: implement delete command for bulletty cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,7 @@ dependencies = [
  "color-eyre",
  "crossterm 0.29.0",
  "dirs",
+ "fuzzt",
  "html2md",
  "open",
  "openssl",
@@ -725,6 +726,12 @@ dependencies = [
  "pin-utils",
  "slab",
 ]
+
+[[package]]
+name = "fuzzt"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a15f3d0fa42283a765e5fb609683ddab4ee4ff245d8db66a24d926c05e518c6"
 
 [[package]]
 name = "getopts"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tracing-appender = "0.2"
 tracing-error = "0.2"
 unicode-width = "0.2.0"
 open = "5.3.2"
+fuzzt = { version = "0.3.1", default-features = false, features = ["levenshtein"] }
 
 [dev-dependencies]
 tempfile = "3.23.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,9 @@
+use std::io;
+
 use clap::{Parser, Subcommand};
 use tracing::info;
 
+use crate::core::library::feeditem::FeedItem;
 use crate::core::library::feedlibrary::FeedLibrary;
 
 #[derive(Parser)]
@@ -25,6 +28,11 @@ pub enum Commands {
     },
     /// Update all feeds
     Update,
+    /// Delete a feed
+    Delete {
+        /// The feed identifier (can be url, title or slug)
+        ident: String,
+    },
 }
 
 pub fn run_main_cli(cli: Cli) -> color_eyre::Result<()> {
@@ -34,6 +42,7 @@ pub fn run_main_cli(cli: Cli) -> color_eyre::Result<()> {
         Some(Commands::List) => command_list(&cli),
         Some(Commands::Add { url, category }) => command_add(&cli, url, category),
         Some(Commands::Update) => command_update(&cli),
+        Some(Commands::Delete { ident }) => command_delete(&cli, ident),
         None => Ok(()),
     }
 }
@@ -71,6 +80,81 @@ fn command_update(_cli: &Cli) -> color_eyre::Result<()> {
             info!("Updating {}", feed.title);
             println!("Updating {}", feed.title);
             library.data.update_feed_entries(category, feed, None)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn command_delete(_cli: &Cli, ident: &str) -> color_eyre::Result<()> {
+    let library = FeedLibrary::new();
+
+    let matches: Vec<&FeedItem> = library.get_matching_feeds(ident);
+    let matches_len = matches.len();
+
+    match matches_len {
+        0 => {
+            info!("No matching feeds exist");
+            println!("No matching feeds exist");
+        }
+        1 => {
+            let matched = matches[0];
+            println!(
+                "Are you sure you want to delete '{}'? That can't be reverted. [y/n]",
+                matched.title
+            );
+
+            let mut choice = String::new();
+            io::stdin().read_line(&mut choice)?;
+
+            let normalized_input = choice.trim().to_lowercase();
+            match normalized_input.as_str() {
+                "y" | "yes" => {
+                    library.delete_feed(&matched.slug, &matched.category)?;
+                    info!("Feed deleted: {}", &matched.title);
+                    println!("Feed deleted: {}", &matched.title);
+                }
+                "n" | "no" => {
+                    info!("Feed was not deleted: {}", &matched.title);
+                    println!("Feed was not deleted: {}", &matched.title);
+                }
+                _ => {
+                    info!("Invalid input received: {}", normalized_input);
+                    println!("Invalid input received: {}", normalized_input);
+                }
+            }
+        }
+        _ => {
+            println!("There were {} feeds found with that identifier:", {
+                matches_len
+            });
+            let iter = matches.iter().enumerate();
+            for (i, feed) in iter {
+                println!("\t-> {}) {}/{}", i + 1, &feed.category, &feed.title);
+            }
+            println!("Which one would you like to delete?");
+
+            let mut choice = String::new();
+            io::stdin().read_line(&mut choice)?;
+
+            let normalized_input = choice.trim();
+
+            match normalized_input.parse::<usize>() {
+                Ok(ind) => {
+                    if ind >= 1 && ind <= matches_len {
+                        library.delete_feed(&matches[ind - 1].slug, &matches[ind - 1].category)?;
+                        info!("Feed deleted: {}", &matches[ind - 1].title);
+                        println!("Feed deleted: {}", &matches[ind - 1].title);
+                    } else {
+                        info!("Invalid input received: {}", ind);
+                        println!("Invalid input received: {}", ind);
+                    }
+                }
+                Err(_) => {
+                    info!("Invalid input received: {}", normalized_input);
+                    println!("Invalid input received: {}", normalized_input);
+                }
+            }
         }
     }
 

--- a/src/core/library/feedlibrary.rs
+++ b/src/core/library/feedlibrary.rs
@@ -1,4 +1,5 @@
 use color_eyre::eyre::eyre;
+use fuzzt::algorithms::normalized_levenshtein;
 use tracing::error;
 
 use crate::{
@@ -165,6 +166,26 @@ impl FeedLibrary {
         } else {
             AppWorkStatus::None
         }
+    }
+
+    pub fn get_matching_feeds(&self, ident: &str) -> Vec<&FeedItem> {
+        let mut matching_vec: Vec<&FeedItem> = Vec::new();
+
+        // Check for matching feeds and push to vec
+        for category in self.feedcategories.iter() {
+            for feed in category.feeds.iter() {
+                let slug_score = normalized_levenshtein(&feed.slug, ident);
+                let title_score = normalized_levenshtein(&feed.title, ident);
+                let url_score = normalized_levenshtein(&feed.feed_url, ident);
+                let max_score = slug_score.max(title_score).max(url_score);
+
+                if max_score > 0.6 {
+                    matching_vec.push(feed);
+                }
+            }
+        }
+
+        matching_vec
     }
 }
 


### PR DESCRIPTION
### Description
This PR implements the functionality of deleting feeds based on `identifier` (can be slug, url or title)

### Key Changes
- Registers a delete command in the cli with `ident` argument representing slug, url or title
- Adds a fn `get_matching_feeds()` in the `impl` block of `FeedLibrary` that is responsible for using `fuzzt normalized_levenshtein similarity algorithm` to compute matching `FeedItem`s beyond a `threshold value (0.6)` and push them to a vector
- The `matches: Vec<&FeedItems>` is used in the interactive cli to selectively delete the user's chosen feed

[todo] Add unit tests

_Note - I use copilot for suggestions, reducing and refactoring code._