### PR TITLE
fix: main thread block

### DIFF
--- a/src/core/ui/appscreen.rs
+++ b/src/core/ui/appscreen.rs
@@ -1,5 +1,5 @@
 use color_eyre::Result;
-use crossterm::event::KeyEvent;
+use crossterm::event::{Event, KeyEvent};
 use ratatui::{Frame, layout::Rect};
 
 use crate::app::AppWorkStatus;
@@ -26,7 +26,7 @@ pub trait AppScreen {
     fn unpause(&mut self);
 
     fn render(&mut self, frame: &mut Frame, area: Rect);
-    fn handle_events(&mut self) -> Result<AppScreenEvent>;
+    fn handle_event(&mut self, event: Event) -> Result<AppScreenEvent>;
     fn handle_keypress(&mut self, key: KeyEvent) -> Result<AppScreenEvent>;
 
     fn get_work_status(&self) -> AppWorkStatus;

--- a/src/ui/screens/helpdialog.rs
+++ b/src/ui/screens/helpdialog.rs
@@ -1,7 +1,5 @@
-use std::time::Duration;
-
 use color_eyre::eyre::Result;
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use ratatui::layout::{Alignment, Constraint, Layout, Margin, Rect};
 use ratatui::style::{Color, Style};
 use ratatui::widgets::{Paragraph, Wrap};
@@ -62,12 +60,8 @@ impl AppScreen for HelpDialog {
         frame.render_widget(content, contentlayout[1]);
     }
 
-    fn handle_events(&mut self) -> Result<AppScreenEvent> {
-        if !event::poll(Duration::from_millis(100)).unwrap_or(true) {
-            return Ok(AppScreenEvent::None);
-        }
-
-        match event::read()? {
+    fn handle_event(&mut self, event: Event) -> Result<AppScreenEvent> {
+        match event {
             Event::Key(key) if key.kind == KeyEventKind::Press => self.handle_keypress(key),
             Event::Mouse(_) => Ok(AppScreenEvent::None),
             Event::Resize(_, _) => Ok(AppScreenEvent::None),

--- a/src/ui/screens/mainscreen.rs
+++ b/src/ui/screens/mainscreen.rs
@@ -1,7 +1,7 @@
-use std::{cell::RefCell, rc::Rc, time::Duration};
+use std::{cell::RefCell, rc::Rc};
 
 use color_eyre::Result;
-use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers};
 use ratatui::{
     layout::{Constraint, Layout, Rect},
     style::{Color, Style, Stylize},
@@ -241,12 +241,8 @@ impl AppScreen for MainScreen {
         frame.render_stateful_widget(scrollbar, chunks[2], &mut scrollbarstate);
     }
 
-    fn handle_events(&mut self) -> Result<AppScreenEvent> {
-        if !event::poll(Duration::from_millis(100)).unwrap_or(true) {
-            return Ok(AppScreenEvent::None);
-        }
-
-        match event::read()? {
+    fn handle_event(&mut self, event: Event) -> Result<AppScreenEvent> {
+        match event {
             Event::Key(key) if key.kind == KeyEventKind::Press => self.handle_keypress(key),
             Event::Mouse(_) => Ok(AppScreenEvent::None),
             Event::Resize(_, _) => Ok(AppScreenEvent::None),

--- a/src/ui/screens/readerscreen.rs
+++ b/src/ui/screens/readerscreen.rs
@@ -1,7 +1,7 @@
-use std::{cell::RefCell, rc::Rc, time::Duration};
+use std::{cell::RefCell, rc::Rc};
 
 use color_eyre::Result;
-use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers};
 use ratatui::layout::{Alignment, Constraint, Layout};
 use ratatui::style::{Color, Style};
 use ratatui::widgets::{
@@ -220,12 +220,8 @@ impl AppScreen for ReaderScreen {
         frame.render_stateful_widget(scrollbar, sizelayout[2], &mut scrollbarstate);
     }
 
-    fn handle_events(&mut self) -> Result<AppScreenEvent> {
-        if !event::poll(Duration::from_millis(100)).unwrap_or(true) {
-            return Ok(AppScreenEvent::None);
-        }
-
-        match event::read()? {
+    fn handle_event(&mut self, event: Event) -> Result<AppScreenEvent> {
+        match event {
             Event::Key(key) if key.kind == KeyEventKind::Press => self.handle_keypress(key),
             Event::Mouse(_) => Ok(AppScreenEvent::None),
             Event::Resize(_, _) => Ok(AppScreenEvent::None),

--- a/src/ui/screens/themedialog.rs
+++ b/src/ui/screens/themedialog.rs
@@ -1,7 +1,7 @@
-use std::{cell::RefCell, rc::Rc, time::Duration};
+use std::{cell::RefCell, rc::Rc};
 
 use color_eyre::eyre::Result;
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use ratatui::layout::{Alignment, Constraint, Layout, Margin, Rect};
 use ratatui::style::{Color, Style};
 use ratatui::widgets::{
@@ -102,12 +102,8 @@ impl AppScreen for ThemeDialog {
         frame.render_stateful_widget(scrollbar, chunks[1], &mut scrollbarstate);
     }
 
-    fn handle_events(&mut self) -> Result<AppScreenEvent> {
-        if !event::poll(Duration::from_millis(100)).unwrap_or(true) {
-            return Ok(AppScreenEvent::None);
-        }
-
-        match event::read()? {
+    fn handle_event(&mut self, event: Event) -> Result<AppScreenEvent> {
+        match event {
             Event::Key(key) if key.kind == KeyEventKind::Press => self.handle_keypress(key),
             Event::Mouse(_) => Ok(AppScreenEvent::None),
             Event::Resize(_, _) => Ok(AppScreenEvent::None),

--- a/src/ui/screens/urldialog.rs
+++ b/src/ui/screens/urldialog.rs
@@ -1,7 +1,5 @@
-use std::time::Duration;
-
 use color_eyre::eyre::Result;
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use ratatui::layout::{Alignment, Constraint, Layout, Margin, Rect};
 use ratatui::style::{Color, Style};
 use ratatui::widgets::{Paragraph, Wrap};
@@ -61,12 +59,8 @@ impl AppScreen for UrlDialog {
         frame.render_widget(content, contentlayout[1]);
     }
 
-    fn handle_events(&mut self) -> Result<AppScreenEvent> {
-        if !event::poll(Duration::from_millis(100)).unwrap_or(true) {
-            return Ok(AppScreenEvent::None);
-        }
-
-        match event::read()? {
+    fn handle_event(&mut self, event: Event) -> Result<AppScreenEvent> {
+        match event {
             Event::Key(key) if key.kind == KeyEventKind::Press => self.handle_keypress(key),
             Event::Mouse(_) => Ok(AppScreenEvent::None),
             Event::Resize(_, _) => Ok(AppScreenEvent::None),


### PR DESCRIPTION
Now the app can re-render dynamic widgets, such as the main screen's status gauge, without having to wait for an event.

Refs: #130