### PR TITLE
fix: Opening in browser should fork the process

### DIFF
--- a/src/ui/screens/mainscreen.rs
+++ b/src/ui/screens/mainscreen.rs
@@ -104,7 +104,7 @@ impl MainScreen {
             )));
         }
 
-        match open::that(url) {
+        match open::that_detached(url) {
             Ok(_) => Ok(AppScreenEvent::Notify(AppNotification::new(
                 "Link opened externally",
                 NotificationPriority::Low,

--- a/src/ui/screens/readerscreen.rs
+++ b/src/ui/screens/readerscreen.rs
@@ -103,7 +103,7 @@ impl ReaderScreen {
             )));
         }
 
-        match open::that(url) {
+        match open::that_detached(url) {
             Ok(_) => Ok(AppScreenEvent::Notify(AppNotification::new(
                 "Link opened externally",
                 NotificationPriority::Low,


### PR DESCRIPTION
`open::that` -> `open::that_detached`

Should resolve https://github.com/crocidb/bulletty/issues/182? I've only got a mac available to me atm, where the bug doesn't seem to manifest for me. Could use a tester for other platforms.