### PR TITLE
feat: Load user themes from file at runtime

### DIFF
--- a/site/docs/docs/cli_reference.md
+++ b/site/docs/docs/cli_reference.md
@@ -86,6 +86,14 @@ Prints the path to the local config directory.
 bulletty dirs local-config
 ```
 
+#### `dirs themes`
+
+Prints the path to the themes directory.
+
+```
+bulletty dirs themes
+```
+
 ### 💠 `import <OPML_FILE>`
 
 Imports feed sources from an OPML file. Most feed readers can export to this format, making it easy to migrate your subscriptions into **bulletty**.

--- a/site/docs/docs/themes.md
+++ b/site/docs/docs/themes.md
@@ -13,7 +13,7 @@ your own.
 ## 📝 Theme File Format
 
 Theme files are written in [TOML](https://toml.io/) format and stored in
-`res/themes/`. Each theme contains:
+the Library under `themes/`. Each theme contains:
 
 ```toml
 scheme = "Theme Name"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,6 +69,8 @@ pub enum DirsCommands {
     Logs,
     /// Show the local config directory
     LocalConfig,
+    /// Show the themes directory
+    Themes,
 }
 
 pub fn run_main_cli(
@@ -240,11 +242,16 @@ fn command_dirs(
             Ok(())
         }
         Some(DirsCommands::Library { path }) => command_dirs_library(path, config, config_store),
+        Some(DirsCommands::Themes) => {
+            command_show_dir(dirs.themes());
+            Ok(())
+        }
         None => {
             println!("bulletty directories\n");
             println!("\t-> Library: {}", config.datapath.to_string_lossy());
             println!("\t-> Logs:    {}", dirs.log().to_string_lossy());
             println!("\t-> Local config:    {}", dirs.config().to_string_lossy());
+            println!("\t-> Themes:    {}", dirs.themes().to_string_lossy());
             println!();
 
             Ok(())

--- a/src/core/defs.rs
+++ b/src/core/defs.rs
@@ -2,6 +2,7 @@ pub const CONFIG_PATH: &str = "bulletty";
 pub const CONFIG_FILE: &str = "config.toml";
 pub const DATA_DIR: &str = "bulletty";
 pub const DATA_CATEGORIES_DIR: &str = "categories";
+pub const DATA_THEMES_DIR: &str = "themes";
 pub const DATA_CATEGORY_DEFAULT: &str = "General";
 pub const DATA_FEED: &str = ".feed.toml";
 pub const LOG_BASE_DIR: &str = "bulletty";

--- a/src/core/library/settings/usersettings.rs
+++ b/src/core/library/settings/usersettings.rs
@@ -1,6 +1,9 @@
 use std::{collections::HashMap, ffi::OsString, fs, path::Path};
 
-use crate::core::library::settings::{appearance::Appearance, theme::Theme, themedata};
+use crate::core::{
+    defs::DATA_THEMES_DIR,
+    library::settings::{appearance::Appearance, theme::Theme, themedata},
+};
 
 pub struct UserSettings {
     pub appearance: Appearance,
@@ -11,10 +14,10 @@ impl UserSettings {
     pub fn new(datapath: &Path) -> color_eyre::Result<Self> {
         let themes_from_library = UserSettings::get_theme_files(datapath);
         let embedded_themes = themedata::get_themes();
-        let themes: HashMap<String, Theme> = themes_from_library
+        let themes = embedded_themes
             .into_iter()
-            .chain(embedded_themes.into_iter())
-            .collect();
+            .chain(themes_from_library.into_iter())
+            .collect::<HashMap<String, Theme>>();
 
         Ok(Self {
             appearance: Appearance::new(datapath)?,
@@ -40,7 +43,7 @@ impl UserSettings {
 
     fn get_theme_files(datapath: &Path) -> HashMap<String, Theme> {
         let theme_file_ext = OsString::from("toml");
-        let themes_path = Path::join(datapath, Path::new("themes"));
+        let themes_path = Path::join(datapath, DATA_THEMES_DIR);
         let mut themes: Vec<Theme> = Vec::new();
 
         if let Ok(entries) = fs::read_dir(themes_path) {

--- a/src/core/library/settings/usersettings.rs
+++ b/src/core/library/settings/usersettings.rs
@@ -12,7 +12,7 @@ pub struct UserSettings {
 
 impl UserSettings {
     pub fn new(datapath: &Path) -> color_eyre::Result<Self> {
-        let themes_from_library = UserSettings::get_theme_files(datapath);
+        let themes_from_library = get_theme_files(datapath);
         let embedded_themes = themedata::get_themes();
         let themes = embedded_themes
             .into_iter()
@@ -40,45 +40,50 @@ impl UserSettings {
     pub fn get_theme_list(&self) -> Vec<String> {
         self.themes.keys().map(|t| t.to_string()).collect()
     }
+}
 
-    fn get_theme_files(datapath: &Path) -> HashMap<String, Theme> {
-        let theme_file_ext = OsString::from("toml");
-        let themes_path = Path::join(datapath, DATA_THEMES_DIR);
-        let mut themes: Vec<Theme> = Vec::new();
+fn get_theme_files(datapath: &Path) -> HashMap<String, Theme> {
+    let theme_file_ext = OsString::from("toml");
+    let themes_path = Path::join(datapath, DATA_THEMES_DIR);
+    let mut themes: Vec<Theme> = Vec::new();
 
-        if let Ok(entries) = fs::read_dir(themes_path) {
-            for entry in entries {
-                if let Ok(entry) = entry
-                    && let path = entry.path()
-                    && path.is_file()
-                    && path.extension() == Some(&theme_file_ext)
-                    && let Ok(content) = fs::read_to_string(&path)
-                    && let Ok(mut theme) = toml::from_str::<Theme>(&content)
-                {
-                    theme.base[0x0] = u32::from_str_radix(&theme.base00, 16).unwrap();
-                    theme.base[0x1] = u32::from_str_radix(&theme.base01, 16).unwrap();
-                    theme.base[0x2] = u32::from_str_radix(&theme.base02, 16).unwrap();
-                    theme.base[0x3] = u32::from_str_radix(&theme.base03, 16).unwrap();
-                    theme.base[0x4] = u32::from_str_radix(&theme.base04, 16).unwrap();
-                    theme.base[0x5] = u32::from_str_radix(&theme.base05, 16).unwrap();
-                    theme.base[0x6] = u32::from_str_radix(&theme.base06, 16).unwrap();
-                    theme.base[0x7] = u32::from_str_radix(&theme.base07, 16).unwrap();
-                    theme.base[0x8] = u32::from_str_radix(&theme.base08, 16).unwrap();
-                    theme.base[0x9] = u32::from_str_radix(&theme.base09, 16).unwrap();
-                    theme.base[0xa] = u32::from_str_radix(&theme.base0A, 16).unwrap();
-                    theme.base[0xb] = u32::from_str_radix(&theme.base0B, 16).unwrap();
-                    theme.base[0xc] = u32::from_str_radix(&theme.base0C, 16).unwrap();
-                    theme.base[0xd] = u32::from_str_radix(&theme.base0D, 16).unwrap();
-                    theme.base[0xe] = u32::from_str_radix(&theme.base0E, 16).unwrap();
-                    theme.base[0xf] = u32::from_str_radix(&theme.base0F, 16).unwrap();
-                    themes.push(theme);
-                }
+    if let Ok(entries) = fs::read_dir(themes_path) {
+        for entry in entries {
+            if let Ok(entry) = entry
+                && let path = entry.path()
+                && path.is_file()
+                && path.extension() == Some(&theme_file_ext)
+                && let Ok(content) = fs::read_to_string(&path)
+                && let Ok(theme) = toml::from_str::<Theme>(&content)
+                && let Ok(theme) = parse_theme_colors(theme)
+            {
+                themes.push(theme);
             }
         }
-
-        themes
-            .iter()
-            .map(|theme| (theme.scheme.clone(), theme.clone()))
-            .collect::<HashMap<String, Theme>>()
     }
+
+    themes
+        .iter()
+        .map(|theme| (theme.scheme.clone(), theme.clone()))
+        .collect::<HashMap<String, Theme>>()
+}
+
+fn parse_theme_colors(mut theme: Theme) -> Result<Theme, std::num::ParseIntError> {
+    theme.base[0x0] = u32::from_str_radix(&theme.base00, 16)?;
+    theme.base[0x1] = u32::from_str_radix(&theme.base01, 16)?;
+    theme.base[0x2] = u32::from_str_radix(&theme.base02, 16)?;
+    theme.base[0x3] = u32::from_str_radix(&theme.base03, 16)?;
+    theme.base[0x4] = u32::from_str_radix(&theme.base04, 16)?;
+    theme.base[0x5] = u32::from_str_radix(&theme.base05, 16)?;
+    theme.base[0x6] = u32::from_str_radix(&theme.base06, 16)?;
+    theme.base[0x7] = u32::from_str_radix(&theme.base07, 16)?;
+    theme.base[0x8] = u32::from_str_radix(&theme.base08, 16)?;
+    theme.base[0x9] = u32::from_str_radix(&theme.base09, 16)?;
+    theme.base[0xa] = u32::from_str_radix(&theme.base0A, 16)?;
+    theme.base[0xb] = u32::from_str_radix(&theme.base0B, 16)?;
+    theme.base[0xc] = u32::from_str_radix(&theme.base0C, 16)?;
+    theme.base[0xd] = u32::from_str_radix(&theme.base0D, 16)?;
+    theme.base[0xe] = u32::from_str_radix(&theme.base0E, 16)?;
+    theme.base[0xf] = u32::from_str_radix(&theme.base0F, 16)?;
+    Ok(theme)
 }

--- a/src/core/library/settings/usersettings.rs
+++ b/src/core/library/settings/usersettings.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::Path};
+use std::{collections::HashMap, ffi::OsString, fs, path::Path};
 
 use crate::core::library::settings::{appearance::Appearance, theme::Theme, themedata};
 
@@ -9,9 +9,16 @@ pub struct UserSettings {
 
 impl UserSettings {
     pub fn new(datapath: &Path) -> color_eyre::Result<Self> {
+        let themes_from_library = UserSettings::get_theme_files(datapath);
+        let embedded_themes = themedata::get_themes();
+        let themes: HashMap<String, Theme> = themes_from_library
+            .into_iter()
+            .chain(embedded_themes.into_iter())
+            .collect();
+
         Ok(Self {
             appearance: Appearance::new(datapath)?,
-            themes: themedata::get_themes(),
+            themes,
         })
     }
 
@@ -29,5 +36,48 @@ impl UserSettings {
 
     pub fn get_theme_list(&self) -> Vec<String> {
         self.themes.keys().map(|t| t.to_string()).collect()
+    }
+
+    fn get_theme_files(datapath: &Path) -> HashMap<String, Theme> {
+        let theme_file_ext = OsString::from("toml");
+        let themes_path = Path::join(datapath, Path::new("themes"));
+        let mut themes: Vec<Theme> = Vec::new();
+
+        if let Ok(entries) = fs::read_dir(themes_path) {
+            for entry in entries {
+                if let Ok(entry) = entry
+                    && let path = entry.path()
+                    && path.is_file()
+                    && path.extension() == Some(&theme_file_ext)
+                    && let Ok(content) = fs::read_to_string(&path)
+                    && let Ok(mut theme) = toml::from_str::<Theme>(&content)
+                {
+                    theme.base[0x0] = u32::from_str_radix(&theme.base00, 16).unwrap();
+                    theme.base[0x1] = u32::from_str_radix(&theme.base01, 16).unwrap();
+                    theme.base[0x2] = u32::from_str_radix(&theme.base02, 16).unwrap();
+                    theme.base[0x3] = u32::from_str_radix(&theme.base03, 16).unwrap();
+                    theme.base[0x4] = u32::from_str_radix(&theme.base04, 16).unwrap();
+                    theme.base[0x5] = u32::from_str_radix(&theme.base05, 16).unwrap();
+                    theme.base[0x6] = u32::from_str_radix(&theme.base06, 16).unwrap();
+                    theme.base[0x7] = u32::from_str_radix(&theme.base07, 16).unwrap();
+                    theme.base[0x8] = u32::from_str_radix(&theme.base08, 16).unwrap();
+                    theme.base[0x9] = u32::from_str_radix(&theme.base09, 16).unwrap();
+                    theme.base[0xa] = u32::from_str_radix(&theme.base0A, 16).unwrap();
+                    theme.base[0xb] = u32::from_str_radix(&theme.base0B, 16).unwrap();
+                    theme.base[0xc] = u32::from_str_radix(&theme.base0C, 16).unwrap();
+                    theme.base[0xd] = u32::from_str_radix(&theme.base0D, 16).unwrap();
+                    theme.base[0xe] = u32::from_str_radix(&theme.base0E, 16).unwrap();
+                    theme.base[0xf] = u32::from_str_radix(&theme.base0F, 16).unwrap();
+                    themes.push(theme);
+                }
+            }
+        }
+
+        let themes_map = themes
+            .iter()
+            .map(|theme| (theme.scheme.clone(), theme.clone()))
+            .collect::<HashMap<String, Theme>>();
+
+        themes_map
     }
 }

--- a/src/core/library/settings/usersettings.rs
+++ b/src/core/library/settings/usersettings.rs
@@ -16,7 +16,7 @@ impl UserSettings {
         let embedded_themes = themedata::get_themes();
         let themes = embedded_themes
             .into_iter()
-            .chain(themes_from_library.into_iter())
+            .chain(themes_from_library)
             .collect::<HashMap<String, Theme>>();
 
         Ok(Self {
@@ -76,11 +76,9 @@ impl UserSettings {
             }
         }
 
-        let themes_map = themes
+        themes
             .iter()
             .map(|theme| (theme.scheme.clone(), theme.clone()))
-            .collect::<HashMap<String, Theme>>();
-
-        themes_map
+            .collect::<HashMap<String, Theme>>()
     }
 }

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -3,12 +3,13 @@ use std::path::{Path, PathBuf};
 use color_eyre::eyre::Result;
 use etcetera::BaseStrategy;
 
-use crate::core::defs::{CONFIG_PATH, DATA_DIR, LOG_BASE_DIR, LOG_SUBDIR};
+use crate::core::defs::{CONFIG_PATH, DATA_DIR, DATA_THEMES_DIR, LOG_BASE_DIR, LOG_SUBDIR};
 
 pub struct Directories {
     log: PathBuf,
     default_data: PathBuf,
     config: PathBuf,
+    themes: PathBuf,
 }
 
 impl Directories {
@@ -23,6 +24,10 @@ impl Directories {
                 .join(LOG_SUBDIR),
             default_data: current_strategy.data_dir().join(DATA_DIR),
             config: current_strategy.config_dir().join(CONFIG_PATH),
+            themes: current_strategy
+                .data_dir()
+                .join(DATA_DIR)
+                .join(DATA_THEMES_DIR),
         })
     }
 
@@ -36,5 +41,9 @@ impl Directories {
 
     pub fn config(&self) -> &Path {
         &self.config
+    }
+
+    pub fn themes(&self) -> &Path {
+        &self.themes
     }
 }


### PR DESCRIPTION
Should close https://github.com/crocidb/bulletty/issues/190 if all is well.

Add a theme TOML file in `themes` in your library folder and you can pick it from the theme picker!
No build required 👍