### PR TITLE
fix: sluggish list scrolling, possible crash when using mouse wheel

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -241,7 +241,7 @@ impl App {
                 let event_available =
                     crossterm::event::poll(self.event_poll_timeout).unwrap_or(true);
                 if event_available {
-                    let terminal_event = crossterm::event::read()?;
+                    let mut terminal_event = crossterm::event::read()?;
 
                     #[cfg(unix)]
                     if let Event::Key(KeyEvent {
@@ -258,6 +258,18 @@ impl App {
                         }
                         terminal = ratatui::init();
                         continue;
+                    }
+
+                    if let Event::Mouse(event) = terminal_event {
+                        let blah = match event.kind {
+                            crossterm::event::MouseEventKind::ScrollUp => Some(KeyCode::Up),
+                            crossterm::event::MouseEventKind::ScrollDown => Some(KeyCode::Down),
+                            _ => None,
+                        };
+
+                        if let Some(blah) = blah {
+                            terminal_event = Event::Key(KeyEvent::new(blah, KeyModifiers::NONE))
+                        }
                     }
 
                     let screen = if let Some(dialog) = self.dialog_queue.get_mut(0) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -261,14 +261,14 @@ impl App {
                     }
 
                     if let Event::Mouse(event) = terminal_event {
-                        let blah = match event.kind {
+                        let key_code = match event.kind {
                             crossterm::event::MouseEventKind::ScrollUp => Some(KeyCode::Up),
                             crossterm::event::MouseEventKind::ScrollDown => Some(KeyCode::Down),
                             _ => None,
                         };
 
-                        if let Some(blah) = blah {
-                            terminal_event = Event::Key(KeyEvent::new(blah, KeyModifiers::NONE))
+                        if let Some(key_code) = key_code {
+                            terminal_event = Event::Key(KeyEvent::new(key_code, KeyModifiers::NONE))
                         }
                     }
 

--- a/src/mainui.rs
+++ b/src/mainui.rs
@@ -1,4 +1,9 @@
+use std::io::stdout;
 use tracing::info;
+use crossterm::{
+    event::{DisableMouseCapture, EnableMouseCapture},
+    execute,
+};
 
 use crate::{app, core::config::Config};
 
@@ -10,9 +15,21 @@ pub fn run_main_ui(config: &Config) -> color_eyre::Result<()> {
     }
 
     let terminal = ratatui::init();
+
+    execute!(stdout(), EnableMouseCapture).ok();
+
+    // update panic hook to DisableMouseCapture on panic
+    let hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        execute!(stdout(), DisableMouseCapture).ok();
+        ratatui::restore();
+        hook(info);
+    }));
+
     let mut app = app::App::new(config);
     app.initmain();
     let result = app.run(terminal);
+    execute!(stdout(), DisableMouseCapture).ok();
     ratatui::restore();
 
     if let Some(hooks) = &config.hooks {

--- a/src/mainui.rs
+++ b/src/mainui.rs
@@ -1,9 +1,9 @@
-use std::io::stdout;
-use tracing::info;
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture},
     execute,
 };
+use std::io::stdout;
+use tracing::info;
 
 use crate::{app, core::config::Config};
 


### PR DESCRIPTION
Fixes https://github.com/crocidb/bulletty/issues/181 ? I don't know why it works, but it works. Tested on mac with kitty, Alacritty, Ghostty and Terminal both with and without tmux.

Enable mouse capture with crossterm
Translate mouse scrollwheel events to keyboard events for KeyCode::Up and KeyCode::Down