### PR TITLE
feat: highlighted code blocks!

### DIFF
--- a/res/syntaxes/CMake.sublime-syntax
+++ b/res/syntaxes/CMake.sublime-syntax
@@ -1,0 +1,660 @@
+%YAML 1.2
+# https://www.sublimetext.com/docs/3/syntax.html
+# https://cmake.org/cmake/help/v3.0/manual/cmake-language.7.html
+--- #---------------------------------------------------------------------------
+name: CMake
+comment: Written by Raoul Wols <raoulwols@gmail.com>, 2017
+file_extensions: [CMakeLists.txt, cmake]
+scope: source.cmake
+#-------------------------------------------------------------------------------
+variables:
+  # Note: we're not doing legacy
+  unquoted_argument_element: "[^ \t()#\"\\']"
+  unquoted_argument: "{{unquoted_argument_element}}+"
+  identifier: \b[[:alpha:]_][[:alnum:]_]*\b
+  generic_named_parameter: \b@?[A-Z_][A-Z0-9_]*(?=[^\w\-<>=\$])
+#-------------------------------------------------------------------------------
+contexts:
+  prototype:
+    - include: comment-block
+    - include: comment-line
+    - include: variable-substitution
+    - include: generator-expression
+
+  main:
+    - include: scope:commands.builtin.cmake#main
+    - include: if
+    - include: foreach
+    - include: while
+    - include: set
+    - include: function
+    - include: macro
+    - include: include
+    - include: illegal-command
+    - include: generic-command
+
+  illegal-command:
+    - match: (?i)\bendif\b
+      scope: invalid.illegal.stray.endif.cmake
+    - match: (?i)\belse\b
+      scope: invalid.illegal.stray.else.cmake
+    - match: (?i)\belseif\b
+      scope: invalid.illegal.stray.elseif.cmake
+    - match: (?i)\bendforeach\b
+      scope: invalid.illegal.stray.endforeach.cmake
+    - match: (?i)\bendwhile\b
+      scope: invalid.illegal.stray.endwhile.cmake
+    - match: (?i)\bbreak\b
+      scope: invalid.illegal.stray.break.cmake
+    - match: (?i)\bendfunction\b
+      scope: invalid.illegal.stray.endfunction.cmake
+    - match: (?i)\bendmacro\b
+      scope: invalid.illegal.stray.endmacro.cmake
+
+  args-illegal-boilerplate:
+    - match: \s+
+    - match: \n
+    - match: .+
+      scope: invalid.illegal.expected-opening-brace.cmake
+      pop: true
+
+  # --- INCLUDE ----------------------------------------------------------------
+
+  include:
+    - match: (?i)\binclude\b
+      scope: keyword.control.import.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: include-args
+        - include: args-illegal-boilerplate
+
+  include-args:
+    - meta_scope: meta.function-call.arguments.cmake
+    - match: \bOPTIONAL\b
+      scope: variable.parameter.include.OPTIONAL.cmake
+    - match: \bNO_POLICY_SCOPE\b
+      scope: variable.parameter.include.NO_POLICY_SCOPE.cmake
+    - match: \bRESULT_VARIABLE\b
+      scope: variable.parameter.include.RESULT_VARIABLE.cmake
+      push:
+        - match: \b{{identifier}}\b
+          scope: variable.other.readwrite.cmake
+          pop: true
+        - match: \s+
+        - match: \n
+        - match: ''
+          pop: true
+    - include: args-common
+
+  # --- FUNCTION / ENDFUNCTION -------------------------------------------------
+
+  function:
+    - match: (?i)\bfunction\b
+      scope: support.function.function.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [function-body, function-args-first]
+        - include: args-illegal-boilerplate
+
+  function-args-first:
+    - meta_scope: meta.function-call.arguments.cmake
+    - match: '{{identifier}}'
+      scope: entity.name.function.cmake
+      set: function-args-rest
+    - include: variable-substitution
+    - match: \s+
+    - match: ''
+      set: function-args-rest
+
+  function-args-rest:
+    - meta_scope: meta.function-call.arguments.cmake
+    - include: args-common
+    - match: '{{identifier}}'
+      scope: variable.parameter.cmake
+
+  function-body:
+    - meta_scope: meta.group.function.cmake
+    - include: endfunction
+    - include: main
+
+  endfunction:
+    - match: (?i)\bendfunction\b
+      scope: support.function.endfunction.cmake
+      set:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: generic-args
+        - include: args-illegal-boilerplate
+
+  # --- MACRO / ENDMACRO -------------------------------------------------------
+
+  macro:
+    - match: (?i)\bmacro\b
+      scope: support.function.macro.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [macro-body, macro-args-first]
+        - include: args-illegal-boilerplate
+
+  macro-args-first:
+    - meta_scope: meta.function-call.arguments.cmake
+    - match: '{{identifier}}'
+      scope: entity.name.function.cmake
+      set: macro-args-rest
+    - include: variable-substitution
+    - match: \s+
+    - match: ''
+      set: macro-args-rest
+
+  macro-args-rest:
+    - meta_scope: meta.function-call.arguments.cmake
+    - include: args-common
+    - match: '{{identifier}}'
+      scope: variable.parameter.cmake
+
+  macro-body:
+    - meta_scope: meta.group.function.cmake
+    - include: endmacro
+    - include: main
+
+  endmacro:
+    - match: (?i)\bendmacro\b
+      scope: support.function.endmacro.cmake
+      set:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: generic-args
+        - include: args-illegal-boilerplate
+
+  # --- IF / ELSEIF / ELSE / ENDIF ---------------------------------------------
+
+  if:
+    - match: (?i)\bif\b
+      scope: keyword.control.if.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [if-body, if-args]
+        - include: args-illegal-boilerplate
+
+  if-body:
+    - meta_scope: meta.group.if.cmake
+    - include: else
+    - include: elseif
+    - include: endif
+    - include: break
+    - include: main
+
+  if-args-inline:
+    - match: \(
+      scope: punctuation.section.parens.begin.cmake
+      push: if-args
+    - match: \bDEFINED\b
+      scope: variable.parameter.if.DEFINED.cmake
+    - match: \bSTREQUAL\b
+      scope: variable.parameter.if.STREQUAL.cmake
+    - match: \bNOT\b
+      scope: keyword.operator.logical.NOT.cmake
+    - match: \bAND\b
+      scope: keyword.operator.logical.AND.cmake
+    - match: \bOR\b
+      scope: keyword.operator.logical.OR.cmake
+    - match: \bCOMMAND\b
+      scope: variable.parameter.if.COMMAND.cmake
+    - match: \bPOLICY\b
+      scope: variable.parameter.if.POLICY.cmake
+    - match: \bTARGET\b
+      scope: variable.parameter.if.TARGET.cmake
+    - match: \bTEST\b
+      scope: variable.parameter.if.TEST.cmake
+    - match: \bEXISTS\b
+      scope: variable.parameter.if.EXISTS.cmake
+    - match: \bIS_NEWER_THAN\b
+      scope: variable.parameter.if.IS_NEWER_THAN.cmake
+    - match: \bIS_DIRECTORY\b
+      scope: variable.parameter.if.IS_DIRECTORY.cmake
+    - match: \bIS_SYMLINK\b
+      scope: variable.parameter.if.IS_SYMLINK.cmake
+    - match: \bIS_ABSOLUTE\b
+      scope: variable.parameter.if.IS_ABSOLUTE.cmake
+    - match: \b(VERSION_|STR)?LESS\b
+      scope: variable.parameter.if.LESS.cmake
+    - match: \b(VERSION_|STR)?GREATER\b
+      scope: variable.parameter.if.GREATER.cmake
+    - match: \b(VERSION_|STR)?EQUAL\b
+      scope: variable.parameter.if.EQUAL.cmake
+    - match: \b(VERSION_|STR)?LESS_EQUAL\b
+      scope: variable.parameter.if.LESS_EQUAL.cmake
+    - match: \b(VERSION_|STR)?GREATER_EQUAL\b
+      scope: variable.parameter.if.GREATER_EQUAL.cmake
+    - match: \bMATCHES\b
+      scope: variable.parameter.if.MATCHES.cmake
+      push:
+        - match: \[(=*)\[
+          captures:
+            1: punctuation.definition.string.begin.cmake
+          push:
+            - meta_include_prototype: false
+            - meta_scope: string.regexp.cmake
+            - match: \]\1\]
+              scope: punctuation.definition.string.end.cmake
+              pop: true
+            - include: scope:source.regexp#base
+        - match: \s+
+        - match: \n
+        - match: ''
+          pop: true
+
+  if-args:
+    - meta_scope: meta.function-call.arguments.cmake
+    - include: if-args-inline
+    - include: args-common
+
+  elseif:
+    - match: (?i)\belseif\b
+      scope: keyword.control.elseif.cmake
+      set:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [elseif-body, if-args]
+        - include: args-illegal-boilerplate
+
+  elseif-body:
+    - meta_scope: meta.group.elseif.cmake
+    - include: elseif
+    - include: else
+    - include: endif
+    - include: break
+    - include: main
+
+  else:
+    - match: (?i)\b\belse\b
+      scope: keyword.control.else.cmake
+      set:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [else-body, if-args]
+        - include: args-illegal-boilerplate
+
+  else-body:
+    - meta_scope: meta.group.else.cmake
+    - include: endif
+    - include: break
+    - include: main
+    - match: (?i)\belse\b
+      scope: invalid.illegal.stray.else.cmake
+    - match: (?i)\belseif\b
+      scope: invalid.illegal.stray.elseif.cmake
+
+  endif:
+    - match: (?i)\bendif\b
+      scope: keyword.control.endif.cmake
+      set:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: if-args
+        - include: args-illegal-boilerplate
+
+  # --- FOREACH / ENDFOREACH ---------------------------------------------------
+
+  foreach:
+    - match: (?i)\bforeach\b
+      scope: keyword.control.foreach.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [foreach-body, foreach-args]
+        - include: args-illegal-boilerplate
+
+  foreach-args:
+    - meta_scope: meta.function-call.arguments.cmake
+    - match: \bIN\b
+      scope: variable.parameter.foreach.IN.cmake
+    - match: \bLISTS\b
+      scope: variable.parameter.foreach.LISTS.cmake
+    - match: \bITEMS\b
+      scope: variable.parameter.foreach.ITEMS.cmake
+    - match: \bRANGE\b
+      scope: variable.parameter.foreach.RANGE.cmake
+    - include: args-common
+
+  foreach-body:
+    - meta_scope: meta.group.foreach.cmake
+    - include: break
+    - include: continue
+    - include: endforeach
+    - include: main
+
+  endforeach:
+    - match: (?i)\bendforeach\b
+      scope: keyword.control.endforeach.cmake
+      set:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: foreach-args
+        - include: args-illegal-boilerplate
+
+  # --- WHILE / ENDWHILE -------------------------------------------------------
+
+  while:
+    - match: (?i)\bwhile\b
+      scope: keyword.control.while.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [while-body, if-args]
+        - include: args-illegal-boilerplate
+
+  while-body:
+    - meta_scope: meta.group.while.cmake
+    - include: break
+    - include: continue
+    - include: endwhile
+    - include: main
+
+  endwhile:
+    - match: (?i)\bendwhile\b
+      scope: keyword.control.endwhile.cmake
+      set:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: if-args
+        - include: args-illegal-boilerplate
+
+  # --- BREAK ------------------------------------------------------------------
+
+  break:
+    - match: (?i)\bbreak\b
+      scope: keyword.control.break.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: break-args
+        - include: args-illegal-boilerplate
+
+  break-args:
+    - meta_scope: meta.function-call.arguments.cmake
+    - include: args-common
+
+  #--- CONTINUE ----------------------------------------------------------------
+
+  continue:
+    - match: (?i)\bcontinue\b
+      scope: keyword.control.continue.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: continue-args
+        - include: args-illegal-boilerplate
+
+  continue-args:
+    - meta_scope: meta.function-call.arguments.cmake
+    - include: args-common
+
+  #--- SET ---------------------------------------------------------------------
+
+  set:
+    - match: (?i)\bset\b
+      scope: support.function.set.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [set-args-rest, set-args-first]
+
+  set-args-first:
+    - match: '{{identifier}}'
+      scope: variable.other.readwrite.assignment.cmake
+      pop: true
+    - include: variable-substitution
+    - match: \s+
+    - match: ''
+      pop: true
+
+  set-args-rest:
+    - meta_scope: meta.function-call.arguments.cmake
+    - match: \bFORCE\b
+      scope: variable.parameter.foreach.FORCE.cmake
+    - match: \bPARENT_SCOPE\b
+      scope: variable.parameter.foreach.PARENT_SCOPE.cmake
+    - match: \bCACHE\b
+      scope: variable.parameter.foreach.CACHE.cmake
+      push:
+        - match: \s*(FILEPATH)
+          captures:
+            1: storage.type.FILEPATH.cmake
+          pop: true
+        - match: \s*(PATH)
+          captures:
+            1: storage.type.PATH.cmake
+          pop: true
+        - match: \s*(STRING)
+          captures:
+            1: storage.type.STRING.cmake
+          pop: true
+        - match: \s*(BOOL)
+          captures:
+            1: storage.type.BOOL.cmake
+          pop: true
+        - match: \s*(INTERNAL)
+          captures:
+            1: storage.type.INTERNAL.cmake
+          pop: true
+        # anything else we scope as an error
+        - match: \s*([^\s]*)
+          captures:
+            1: invalid.illegal.expected-type.cmake
+          pop: true
+    - include: args-common
+
+  #--- COMMON FUNCTIONALITY FOR COMMANDS ---------------------------------------
+
+  args-common:
+    - match: \)
+      scope: punctuation.section.parens.end.cmake
+      pop: true
+    - match: \(
+      scope: invalid.illegal.stray.parenthesis.cmake
+    - include: string
+
+  generic-command:
+    - match: \b{{identifier}}\b
+      scope: variable.function.generic.cmake
+      push:
+        - meta_scope: meta.function-call.generic.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: generic-args
+
+  generic-args:
+    - meta_scope: meta.function-call.arguments.generic.cmake
+    - match: \)
+      scope: punctuation.section.parens.end.cmake
+      pop: true
+    # This might be useful for commands which take literal condition expressions as arguments
+    - include: if-args-inline
+    - match: (?={{generic_named_parameter}})
+      push: unquoted-argument-or-keyword
+    - include: string-unquoted
+    - include: string-quoted-double
+
+  # https://cmake.org/cmake/help/v3.0/manual/cmake-language.7.html#unquoted-argument
+  unquoted-argument-or-keyword:
+    - meta_scope: variable.parameter.generic.cmake
+    - match: (?=\t| |\(|\)|\#|\"|\\)
+      pop: true
+
+  #--- STRING HANDLING ---------------------------------------------------------
+
+  string:
+    - include: string-raw
+    - include: string-quoted-double
+    - include: string-unquoted
+
+  string-raw:
+    - match: \[(=*)\[
+      scope: punctuation.definition.string.begin.cmake
+      push:
+        - meta_include_prototype: false
+        - meta_scope: string.raw.cmake
+        - match: \]\1\]
+          scope: punctuation.definition.string.end.cmake
+          pop: true
+
+  string-quoted-double:
+    - match: '"'
+      scope: punctuation.definition.string.begin.cmake
+      push:
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.double.cmake
+        - match: '"'
+          scope: punctuation.definition.string.end.cmake
+          pop: true
+        - include: escape-sequences
+        - include: highlight-semicolon
+        - include: variable-substitution
+        - include: generator-expression
+
+
+  string-unquoted:
+    - match: (?={{unquoted_argument}})
+      push:
+        - meta_include_prototype: false
+        - meta_scope: meta.string.unquoted.cmake
+        - include: variable-substitution
+        - include: generator-expression
+        - match: \\[; ()#"\\]
+          scope: constant.character.escape.cmake
+        - match: \\.
+          scope: invalid.illegal.character.escape.cmake
+        - match: (?=\t| |\(|\)|\#|\"|\\|\n)
+          pop: true
+        - match: (?=\s*$)
+          set:
+            - match: \s*$
+              pop: true
+        - match: (?=\s*#)
+          set: prototype
+        - include: highlight-semicolon
+
+  highlight-semicolon:
+    - match: ;
+      scope: punctuation.separator.cmake
+
+  escape-sequences:
+    - match: \\[()#" \\$@^trn;]
+      scope: constant.character.escape.cmake
+    - match: \\.
+      scope: invalid.illegal.character.escape.cmake
+
+  #--- VARIABLES AND GENERATOR EXPRESSIONS -------------------------------------
+
+  variable-substitution:
+    - match: (\$)(ENV)?(\{)
+      captures:
+        1: punctuation.definition.variable.substitution.cmake
+        2: keyword.operator.word.cmake
+        3: punctuation.section.braces.begin.cmake
+      push:
+        - meta_scope: meta.text-substitution.cmake
+        - match: \}
+          scope: punctuation.section.braces.end.cmake
+          pop: true
+        - match: '{{identifier}}'
+          scope: variable.other.readwrite.cmake
+        - include: prototype
+
+  generator-expression:
+    - match: (\$)(<)
+      captures:
+        1: punctuation.definition.variable.generator-expression.cmake
+        2: punctuation.section.block.begin.cmake
+      push:
+        - meta_scope: meta.generator-expression.cmake
+        - include: generator-expression-common
+        - match: ':'
+          scope: punctuation.separator.generator-expression.cmake
+          set:
+            - meta_content_scope: meta.generator-expression.cmake
+            - include: generator-expression-common
+            - include: variable-substitution
+            - include: generator-expression
+        - include: prototype
+
+  generator-expression-common:
+    - match: '>'
+      scope: punctuation.section.block.end.cmake
+      pop: true
+    - match: '{{identifier}}'
+      scope: variable.other.readwrite.cmake
+
+  #--- COMMENT HANDLING --------------------------------------------------------
+
+  comment-block:
+    - match: \#\[(=*)\[
+      scope: punctuation.definition.comment.begin.cmake
+      push:
+        - meta_scope: comment.block.cmake
+        - match: \]\1\]
+          scope: punctuation.definition.comment.end.cmake
+          pop: true
+
+  comment-line:
+    - match: \#
+      scope: punctuation.definition.comment.cmake
+      push:
+        - meta_scope: comment.line.cmake
+        - match: $
+          pop: true

--- a/res/syntaxes/Dockerfile.sublime-syntax
+++ b/res/syntaxes/Dockerfile.sublime-syntax
@@ -1,0 +1,119 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: Dockerfile
+scope: source.dockerfile
+
+file_extensions:
+  - Dockerfile
+  - dockerfile
+
+hidden_file_extensions:
+  - .Dockerfile
+
+first_line_match: ^\s*(?i:(from(?!\s+\S+\s+import)|arg))\s+
+
+variables:
+  onbuild_directive: (?i:(onbuild)\s+)?
+  onbuild_commands_directive:
+    "{{onbuild_directive}}(?i:add|arg|env|expose|healthcheck|label|run|shell|stopsignal|user|volume|workdir)"
+  nononbuild_commands_directive: (?i:maintainer)
+  runtime_directive: "{{onbuild_directive}}(?i:cmd|entrypoint)"
+  from_directive: (?i:(from))\s+[^\s:@]+(?:[:@](\S+))?(?:\s+(?i:(as))\s+(\S+))?
+  copy_directive: ({{onbuild_directive}}(?i:copy))(?:\s+--from=(\S+))?
+
+contexts:
+  main:
+    - include: comments
+    - match: ^(?i:arg)\s
+      scope: keyword.control.dockerfile
+    - include: from
+
+  from:
+    - match: ^{{from_directive}}
+      captures:
+        1: keyword.control.dockerfile
+        2: entity.name.enum.tag-digest
+        3: keyword.control.dockerfile
+        4: variable.stage-name
+      push: body
+
+  body:
+    - include: comments
+    - include: directives
+    - include: invalid
+    - include: from
+
+  directives:
+    - match: ^\s*{{onbuild_commands_directive}}\s
+      captures:
+        0: keyword.control.dockerfile
+        1: keyword.other.special-method.dockerfile
+      push: args
+    - match: ^\s*{{nononbuild_commands_directive}}\s
+      scope: keyword.control.dockerfile
+      push: args
+    - match: ^\s*{{copy_directive}}\s
+      captures:
+        1: keyword.control.dockerfile
+        2: keyword.other.special-method.dockerfile
+        3: variable.stage-name
+      push: args
+    - match: ^\s*{{runtime_directive}}\s
+      captures:
+        0: keyword.operator.dockerfile
+        1: keyword.other.special-method.dockerfile
+      push: args
+
+  escaped-char:
+    - match: \\.
+      scope: constant.character.escaped.dockerfile
+
+  args:
+    - include: comments
+    - include: escaped-char
+    - match: ^\s*$
+    - match: \\\s+$
+    - match: \n
+      pop: true
+    - match: '"'
+      scope: punctuation.definition.string.begin.dockerfile
+      push: double_quote_string
+    - match: "'"
+      scope: punctuation.definition.string.begin.dockerfile
+      push: single_quote_string
+
+  double_quote_string:
+    - meta_scope: string.quoted.double.dockerfile
+    - include: escaped-char
+    - match: ^\s*$
+    - match: \\\s+$
+    - match: \n
+      set: invalid
+    - match: '"'
+      scope: punctuation.definition.string.end.dockerfile
+      pop: true
+
+  single_quote_string:
+    - meta_scope: string.quoted.single.dockerfile
+    - include: escaped-char
+    - match: ^\s*$
+    - match: \\\s+$
+    - match: \n
+      set: invalid
+    - match: "'"
+      scope: punctuation.definition.string.end.dockerfile
+      pop: true
+
+  comments:
+    - match: ^(\s*)((#).*$\n?)
+      comment: comment.line
+      captures:
+        1: punctuation.whitespace.comment.leading.dockerfile
+        2: comment.dockerfile
+        3: punctuation.definition.comment.dockerfile
+
+  invalid:
+    - match: ^[^A-Z\n](.*)$
+      scope: invalid
+      set: body

--- a/res/syntaxes/DotENV.sublime-syntax
+++ b/res/syntaxes/DotENV.sublime-syntax
@@ -1,0 +1,98 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: DotENV
+file_extensions:
+  - .env
+  - .env.dist
+  - .env.local
+  - .env.sample
+  - .env.example
+  - .env.template
+  - .env.test
+  - .env.test.local
+  - .env.testing
+  - .env.dev
+  - .env.development
+  - .env.development.local
+  - .env.prod
+  - .env.production
+  - .env.production.local
+  - .env.dusk.local
+  - .env.staging
+  - .env.default
+  - .env.defaults
+  - .envrc
+  - .flaskenv
+  - env
+  - env.example
+  - env.sample
+  - env.template
+scope: source.env
+contexts:
+  main:
+    - match: (#).*$\n?
+      comment: "Comments - starts with #"
+      scope: comment.line.number-sign.env
+      captures:
+        1: punctuation.definition.comment.env
+    - match: (\")
+      comment: Strings (double)
+      captures:
+        1: punctuation.definition.string.begin.env
+      push:
+        - meta_scope: string.quoted.double.env
+        - match: (\")
+          captures:
+            1: punctuation.definition.string.end
+          pop: true
+        - include: interpolation
+        - include: variable
+        - include: escape-characters
+    - match: (\')
+      comment: Strings (single)
+      captures:
+        1: punctuation.definition.string.begin.env
+      push:
+        - meta_scope: string.quoted.single.env
+        - match: (\')
+          captures:
+            1: punctuation.definition.string.end
+          pop: true
+    - match: '(?<=[\w])\s?='
+      comment: Assignment Operator
+      scope: keyword.operator.assignment.env
+    - match: '([\w]+)(?=\s?\=)'
+      comment: Variable
+      scope: variable.other.env
+    - match: (?i)\s?(export)
+      comment: Keywords
+      scope: keyword.other.env
+    - match: (?i)(?<=\=)\s?(true|false|null)
+      comment: Constants
+      scope: constant.language.env
+    - match: '\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)\b'
+      comment: Numeric
+      scope: constant.numeric.env
+  escape-characters:
+    - match: '\\[nrt\\\$\"\'']'
+      scope: constant.character.escape.env
+  interpolation:
+    - match: '(\$\{|\{)'
+      comment: 'Template Syntax: "foo ${bar} {$baz}"'
+      captures:
+        1: string.interpolated.env keyword.other.template.begin.env
+      push:
+        - match: '(\})'
+          captures:
+            1: string.interpolated.env keyword.other.template.end.env
+          pop: true
+        - match: '(?x)(\$+)?([a-zA-Z_\x{7f}-\x{ff}][a-zA-Z0-9_\x{7f}-\x{ff}]*?\b)'
+          captures:
+            1: punctuation.definition.variable.env variable.other.env
+            2: variable.other.env
+  variable:
+    - match: '(?x)(\$+)([a-zA-Z_\x{7f}-\x{ff}][a-zA-Z0-9_\x{7f}-\x{ff}]*?\b)'
+      captures:
+        1: punctuation.definition.variable.env variable.other.env
+        2: variable.other.env

--- a/res/syntaxes/GraphQL.sublime-syntax
+++ b/res/syntaxes/GraphQL.sublime-syntax
@@ -1,0 +1,595 @@
+%YAML 1.2
+---
+# See http://www.sublimetext.com/docs/3/syntax.html
+name: GraphQL
+file_extensions:
+  - graphql
+  - graphqls
+  - gql
+scope: source.graphql
+variables:
+  name_begin: (?:[_A-Za-z])
+  name_continue: (?:[_0-9A-Za-z])
+  name_break: (?!{{name_continue}})
+  name: (?:{{name_begin}}{{name_continue}}*{{name_break}})
+
+  integer_part: (?:-?(?:0|[1-9]\d*))
+  fractional_part: (?:\.\d*)
+  exponent_part: (?:[Ee][-+]?\d*)
+contexts:
+  else-pop:
+    - match: (?=\S)
+      pop: true
+
+  immediately-pop:
+    - match: ''
+      pop: true
+
+  prototype:
+    - match: '#'
+      scope: punctuation.definition.comment.graphql
+      push:
+        - meta_scope: comment.line.graphql
+        - match: $
+          pop: true
+    - match: ','
+      scope: punctuation.separator.sequence.graphql
+
+  main:
+    - match: (?=")
+      push: description
+
+    - include: executable-declaration
+    - include: type-declarations
+
+    - match: directive{{name_break}}
+      scope: keyword.declaration.directive.graphql
+      push:
+        - - match: on{{name_break}}
+            scope: keyword.declaration.directive.graphql
+            set:
+              - - match: '\|'
+                  scope: keyword.operator.graphql
+                  push: directive-location
+                - include: else-pop
+              - directive-location
+          - include: else-pop
+        - arguments-definition
+        - directive-definition-name
+
+  executable-declaration:
+    - match: query{{name_break}}
+      scope: keyword.declaration.query.graphql
+      push:
+        - selection-set
+        - directives
+        - variable-definitions
+        - query-name
+
+    - match: (?=\{)
+      push: selection-set
+
+    - match: mutation{{name_break}}
+      scope: keyword.declaration.mutation.graphql
+      push:
+        - selection-set
+        - directives
+        - variable-definitions
+        - mutation-name
+
+    - match: subscription{{name_break}}
+      scope: keyword.declaration.subscription.graphql
+      push:
+        - selection-set
+        - directives
+        - variable-definitions
+        - subscription-name
+
+    - match: fragment{{name_break}}
+      scope: keyword.declaration.fragment.graphql
+      push:
+        - selection-set
+        - directives
+        - type-condition
+        - fragment-name
+
+  type-declarations:
+    - match: schema{{name_break}}
+      scope: keyword.declaration.schema.graphql
+      push:
+        - schema-definition
+        - directives
+
+    - match: scalar{{name_break}}
+      scope: keyword.declaration.scalar.graphql
+      push:
+        - directives
+        - scalar-name
+
+    - match: type{{name_break}}
+      scope: keyword.declaration.type.graphql
+      push:
+        - type-definition
+        - directives
+        - implements
+        - type-name
+
+    - match: interface{{name_break}}
+      scope: keyword.declaration.type.interface.graphql
+      push:
+        - type-definition
+        - directives
+        - implements
+        - interface-name
+
+    - match: union{{name_break}}
+      scope: keyword.declaration.type.interface.graphql
+      push:
+        - - match: '='
+            scope: punctuation.separator.key-value.graphql
+            set:
+              - - match: '\|'
+                  scope: keyword.operator.graphql
+                  push: type-named
+                - include: else-pop
+              - - include: type-named
+                - include: else-pop
+          - include: else-pop
+        - directives
+        - union-name
+
+    - match: enum{{name_break}}
+      scope: keyword.declaration.type.enum.graphql
+      push:
+        - enum-definition
+        - directives
+        - enum-name
+
+    - match: input{{name_break}}
+      scope: keyword.declaration.type.input.graphql
+      push:
+        - input-definition
+        - directives
+        - input-name
+
+  description:
+    - match: '"""'
+      scope: string.quoted.multiline.begin.graphql
+      set:
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.multiline.graphql
+        - match: '\\"""'
+          scope: constant.character.escape.graphql
+        - match: '"""'
+          scope: string.quoted.multiline.end.graphql
+          pop: true
+
+    - match: '"'
+      scope: string.quoted.double.begin.graphql
+      set:
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.double.graphql
+        - match: '"'
+          scope: string.quoted.double.end.graphql
+          pop: true
+
+        - match: '\\u\h{4}'
+          scope: constant.character.escape.hex.graphql
+        - match: '\\u\h{,3}'
+          scope: invalid.illegal.escape.hex.graphql
+
+        - match: '\\["\\/bfnrt]'
+          scope: constant.character.escape.graphql
+        - match: '\\.'
+          scope: invalid.illegal.escape.graphql
+
+  query-name:
+    - match: '{{name}}'
+      scope: entity.name.query.graphql
+      pop: true
+    - include: else-pop
+
+  mutation-name:
+    - match: '{{name}}'
+      scope: entity.name.mutation.graphql
+      pop: true
+    - include: else-pop
+
+  subscription-name:
+    - match: '{{name}}'
+      scope: entity.name.subscription.graphql
+      pop: true
+    - include: else-pop
+
+  fragment-name:
+    - match: (?=on{{name_break}})
+      pop: true
+    - match: '{{name}}'
+      scope: entity.name.fragment.graphql
+      pop: true
+    - include: else-pop
+
+  scalar-name:
+    - match: '{{name}}'
+      scope: entity.name.type.scalar.graphql
+      pop: true
+    - include: else-pop
+
+  type-name:
+    - match: '{{name}}'
+      scope: entity.name.type.object.graphql
+      pop: true
+    - include: else-pop
+
+  interface-name:
+    - match: '{{name}}'
+      scope: entity.name.type.interface.graphql
+      pop: true
+    - include: else-pop
+
+  union-name:
+    - match: '{{name}}'
+      scope: entity.name.type.union.graphql
+      pop: true
+    - include: else-pop
+
+  enum-name:
+    - match: '{{name}}'
+      scope: entity.name.type.enum.graphql
+      pop: true
+    - include: else-pop
+
+  input-name:
+    - match: '{{name}}'
+      scope: entity.name.type.input.graphql
+      pop: true
+    - include: else-pop
+
+  directive-definition-name:
+    - match: '(@)({{name}})'
+      captures:
+        1: punctuation.definition.annotation.graphql
+        2: entity.name.definition.graphql
+      pop: true
+    - include: else-pop
+
+  type-condition:
+    - match: on{{name_break}}
+      scope: keyword.other.graphql
+      set: type-named
+    - include: else-pop
+
+  default-value:
+    - match: '='
+      scope: punctuation.separator.key-value.graphql
+      set: value
+    - include: else-pop
+
+  variable-definitions:
+    - match: \(
+      scope: punctuation.section.group.begin.graphql
+      set:
+      - match: \)
+        scope: punctuation.section.group.end.graphql
+        pop: true
+      - match: '(\$)({{name}})'
+        captures:
+          1: punctuation.definition.variable.graphql
+          2: variable.parameter.graphql
+        push:
+          - - include: default-value
+          - - match: ':'
+              scope: punctuation.separator.type.graphql
+              set: type
+            - include: else-pop
+    - include: else-pop
+
+  directives:
+    - match: '@'
+      scope: punctuation.definition.annotation.graphql
+      push:
+        - arguments
+        - directive-name
+
+    - include: else-pop
+
+  directive-name:
+    - match: (?:skip|include|deprecated){{name_break}}
+      scope: variable.function.annotation.graphql support.function.graphql
+      pop: true
+    - match: '{{name}}'
+      scope: variable.function.annotation.graphql
+      pop: true
+    - include: else-pop
+
+  selection-set:
+    - match: \{
+      scope: punctuation.section.block.begin.graphql
+      set:
+        - meta_scope: meta.block.graphql
+        - match: \}
+          scope: punctuation.section.block.end.graphql
+          pop: true
+        - match: '{{name}}'
+          scope: entity.name.field.graphql
+          push:
+            - selection-set
+            - directives
+            - field-arguments
+            - aliased-field-name
+    - include: else-pop
+
+  aliased-field-name:
+    - match: ':'
+      scope: punctuation.separator.key-value.graphql
+      set:
+      - match: '{{name}}'
+        scope: variable.parameter.graphql
+        pop: true
+      - include: else-pop
+    - include: else-pop
+
+  field-arguments:
+    - match: \(
+      scope: punctuation.section.group.begin.graphql
+      set:
+      - match: \)
+        scope: punctuation.section.group.end.graphql
+        pop: true
+      - match: '{{name}}'
+        scope: variable.parameter.graphql
+        push:
+          - - match: ':'
+              scope: punctuation.separator.type.graphql
+              set: value
+            - include: else-pop
+    - include: else-pop
+
+  schema-definition:
+    - match: \{
+      scope: punctuation.section.block.begin.graphql
+      set:
+        - meta_scope: meta.block.graphql
+        - match: \}
+          scope: punctuation.section.block.end.graphql
+          pop: true
+        - match: '(?:query|mutation|subscription)'
+          scope: keyword.other.graphql
+          push:
+            - match: ':'
+              scope: punctuation.separator.key-value.graphql
+              set: type-named
+            - include: else-pop
+    - include: else-pop
+
+  implements:
+    - match: implements{{name_break}}
+      scope: keyword.declaration.implements.graphql
+      set:
+        - - match: '&'
+            scope: keyword.operator.graphql
+            push: type-named
+          - include: else-pop
+        - - include: type-named
+          - include: else-pop
+    - include: else-pop
+
+  type-definition:
+    - match: \{
+      scope: punctuation.section.block.begin.graphql
+      set:
+        - meta_scope: meta.block.graphql
+        - match: \}
+          scope: punctuation.section.block.end.graphql
+          pop: true
+        - match: (?=")
+          push: description
+        - match: '{{name}}'
+          scope: entity.name.field.graphql
+          push:
+            - - match: ':'
+                scope: punctuation.separator.key-value.graphql
+                set:
+                  - directives
+                  - type
+              - include: else-pop
+            - arguments-definition
+    - include: else-pop
+
+  enum-definition:
+    - match: \{
+      scope: punctuation.section.block.begin.graphql
+      set:
+        - meta_scope: meta.block.graphql
+        - match: \}
+          scope: punctuation.section.block.end.graphql
+          pop: true
+        - match: (?=")
+          push: description
+        - match: '{{name}}'
+          scope: entity.name.constant.graphql
+          push: directives
+    - include: else-pop
+
+  input-definition:
+    - match: \{
+      scope: punctuation.section.block.begin.graphql
+      set:
+        - meta_scope: meta.block.graphql
+        - match: \}
+          scope: punctuation.section.block.end.graphql
+          pop: true
+        - include: input-value-definition
+    - include: else-pop
+
+  arguments-definition:
+    - match: \(
+      scope: punctuation.section.group.begin.graphql
+      set:
+        - match: \)
+          scope: punctuation.section.group.end.graphql
+          pop: true
+        - include: input-value-definition
+    - include: else-pop
+
+  input-value-definition:
+    - match: (?=")
+      push: description
+    - match: '{{name}}'
+      scope: variable.parameter.graphql
+      push:
+        - match: ':'
+          scope: punctuation.separator.key-value
+          set:
+            - directives
+            - default-value
+            - type
+        - include: else-pop
+
+  type:
+    - meta_include_prototype: false
+    - match: ''
+      set:
+        - type-non-null
+        - type-value
+
+  type-value:
+    - include: type-named
+    - match: \[
+      scope: storage.modifier.list.graphql
+      set:
+        - - match: \]
+            scope: storage.modifier.list.graphql
+            pop: true
+          - include: else-pop
+        - type
+    - include: else-pop
+
+  type-named:
+    - match: (?:Int|Float|String|Boolean|ID){{name_break}}
+      scope: variable.type.graphql support.type.graphql
+      pop: true
+    - match: '{{name}}'
+      scope: variable.type.graphql
+      pop: true
+
+  type-non-null:
+    - match: '!'
+      scope: storage.modifier.required.graphql
+      pop: true
+    - include: else-pop
+
+  directive-location:
+    - match: |
+        (?x)(?:
+          QUERY|MUTATION|SUBSCRIPTION|FIELD|FRAGMENT_DEFINITION|FRAGMENT_SPREAD|INLINE_FRAGMENT
+          |SCHEMA|SCALAR|OBJECT|FIELD_DEFINITION|ARGUMENT_DEFINITION|INTERFACE|UNION|ENUM|ENUM_VALUE|INPUT_OBJECT|INPUT_FIELD_DEFINITION
+        ){{name_break}}
+      scope: constant.language.graphql
+      pop: true
+    - include: else-pop
+
+  arguments:
+    - match: \(
+      scope: punctuation.section.group.begin.graphql
+      set:
+      - match: \)
+        scope: punctuation.section.group.end.graphql
+        pop: true
+      - match: '{{name}}'
+        scope: variable.parameter.graphql
+        push:
+          - match: ':'
+            scope: punctuation.separator.key-value.graphql
+            set: value
+          - include: else-pop
+      - include: else-pop
+    - include: else-pop
+
+  value:
+    - match: \$
+      scope: punctuation.definition.variable.graphql
+      set:
+        - match: '{{name}}'
+          scope: variable.other.graphql
+          pop: true
+        - include: ''
+          pop: true
+
+    - match: '{{integer_part}}(?:{{fractional_part}}{{exponent_part}}?|{{exponent_part}}){{name_break}}'
+      scope: constant.numeric.float.graphql
+      pop: true
+    - match: '{{integer_part}}{{name_break}}'
+      scope: constant.numeric.integer.graphql
+      pop: true
+
+    - match: null{{name_break}}
+      scope: constant.language.null.graphql
+      pop: true
+    - match: true{{name_break}}
+      scope: constant.language.boolean.true.graphql
+      pop: true
+    - match: false{{name_break}}
+      scope: constant.language.boolean.false.graphql
+      pop: true
+
+    - match: '{{name}}'
+      scope: constant.other.graphql
+      pop: true
+
+    - match: '"""'
+      scope: punctuation.definition.string.begin.graphql
+      set:
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.triple.graphql
+        - match: '\\"""'
+          scope: constant.character.escape.graphql
+        - match: '"""'
+          scope: punctuation.definition.string.end.graphql
+          pop: true
+
+    - match: '"'
+      scope: punctuation.definition.string.begin.graphql
+      set:
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.double.graphql
+        - match: '"'
+          scope: punctuation.definition.string.end.graphql
+          pop: true
+
+        - match: '\\u\h{4}'
+          scope: constant.character.escape.hex.graphql
+        - match: '\\u\h{,3}'
+          scope: invalid.illegal.escape.hex.graphql
+
+        - match: '\\["\\/bfnrt]'
+          scope: constant.character.escape.graphql
+        - match: '\\.'
+          scope: invalid.illegal.escape.graphql
+
+    - match: \[
+      scope: punctuation.section.sequence.begin.graphql
+      set:
+        - meta_scope: meta.sequence.graphql
+        - match: \]
+          scope: punctuation.section.sequence.end.graphql
+          pop: true
+        - match: (?=\S)
+          push: value
+
+    - match: \{
+      scope: punctuation.section.mapping.begin.graphql
+      set:
+        - meta_scope: meta.mapping.graphql
+        - match: \}
+          scope: punctuation.section.mapping.end.graphql
+          pop: true
+        - match: '{{name}}'
+          scope: meta.mapping.key.graphql
+          push:
+            - match: ':'
+              scope: punctuation.separator.key-value.graphql
+              set: value
+            - include: else-pop
+
+    - include: else-pop

--- a/res/syntaxes/INI.sublime-syntax
+++ b/res/syntaxes/INI.sublime-syntax
@@ -1,0 +1,50 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: INI
+file_extensions:
+  - ini
+  - INI
+  - "inf"
+  - "INF"
+  - reg
+  - REG
+  - lng
+  - cfg
+  - CFG
+  - desktop
+  - url
+  - URL
+  - .editorconfig
+  - .coveragerc
+  - .pylintrc
+  - .gitlint
+  - .hgrc
+  - hgrc
+scope: source.ini
+contexts:
+  main:
+    - match: ^\s*(;|#).*$\n?
+      scope: comment.line.semicolon.ini
+      captures:
+        1: punctuation.definition.comment.ini
+    - match: '^\s*(\[)(.*?)(\])\s*(;.*)?$\n?'
+      scope: meta.tag.section.ini
+      captures:
+        1: punctuation.definition.section.ini
+        2: entity.section.ini
+        3: punctuation.definition.section.ini
+        4: comment.definition.section.ini
+    - match: '^(\s*(["'']?)(.+?)(\2)\s*(=))?\s*((["'']?)(.*?)(\7))\s*(;.*)?$\n?'
+      scope: meta.declaration.ini
+      captures:
+        1: meta.property.ini
+        2: punctuation.definition.quote.ini
+        3: keyword.name.ini
+        4: punctuation.definition.quote.ini
+        5: punctuation.definition.equals.ini
+        6: meta.value.ini
+        7: punctuation.definition.quote.ini
+        8: string.name.value.ini
+        9: punctuation.definition.quote.ini
+        10: comment.declarationline.semicolon.ini

--- a/res/syntaxes/TOML.sublime-syntax
+++ b/res/syntaxes/TOML.sublime-syntax
@@ -1,0 +1,419 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: TOML
+
+file_extensions:
+  - toml
+  - tml
+  - Cargo.lock
+  - Gopkg.lock
+  - Pipfile
+  - pdm.lock
+  - poetry.lock
+  - uv.lock
+
+scope: source.toml
+
+variables:
+  ws: '[ \t]*'
+  wsnl: '(?:[ \t\n]*)'
+
+  # Used to detect the possible start of a key.
+  peek_key_start: '(?=[A-Za-z0-9_''"-])'
+  dot_peek_key: '{{ws}}(\.){{ws}}{{peek_key_start}}'
+
+  # integer = [ "-" / "+" ] int
+  # int = DIGIT / digit1-9 1*( DIGIT / "_" DIGIT )
+  integer: '([\+\-]?) (?: [0-9] | [1-9] (?: [0-9] | _ [0-9] )+ )'
+
+  HEXDIG: '[0-9A-Fa-f]'
+  hex_int: '0x{{HEXDIG}}(?:{{HEXDIG}}|_{{HEXDIG}})*'
+  oct_int: '0o[0-7](?:[0-7]|_[0-7])*'
+  bin_int: '0b[0-1](?:[0-1]|_[0-1])*'
+
+  # zero-prefixable-int = DIGIT *( DIGIT / underscore DIGIT )
+  zero_prefixable_int: '[0-9] (?: [0-9] | _ [0-9] )*'
+  # frac = decimal-point zero-prefixable-int
+  frac: '\. {{zero_prefixable_int}}'
+  # exp = "e" float-exp-part
+  # float-exp-part = [ minus / plus ] zero-prefixable-int
+  exp: '[eE] [\+\-]? {{zero_prefixable_int}}'
+
+  # date-time      = offset-date-time / local-date-time / local-date / local-time
+  date_time: '{{offset_date_time}} | {{local_date_time}} | {{local_date}} | {{local_time}}'
+  # date-fullyear  = 4DIGIT
+  date_fullyear: '[0-9]{4}'
+  # date-month     = 2DIGIT  ; 01-12
+  date_month: '[0-1][0-9]'
+  # date-mday      = 2DIGIT  ; 01-28, 01-29, 01-30, 01-31 based on month/year
+  date_mday: '[0-3][0-9]'
+  # time-hour      = 2DIGIT  ; 00-23
+  time_hour: '[0-2][0-9]'
+  # time-minute    = 2DIGIT  ; 00-59
+  time_minute: '[0-5][0-9]'
+  # time-second    = 2DIGIT  ; 00-58, 00-59, 00-60 based on leap second rules
+  time_second: '[0-6][0-9]'
+  # time-secfrac   = "." 1*DIGIT
+  time_secfrac: '\.[0-9]+'
+  # time-numoffset = ( "+" / "-" ) time-hour ":" time-minute
+  time_numoffset: '[+-] {{time_hour}} : {{time_minute}}'
+  # time-offset    = "Z" / time-numoffset
+  time_offset: '(?: [zZ] | {{time_numoffset}} )'
+  # partial-time   = time-hour ":" time-minute ":" time-second [time-secfrac]
+  partial_time: '{{time_hour}} : {{time_minute}} : {{time_second}} (?: {{time_secfrac}} )?'
+  # full-date      = date-fullyear "-" date-month "-" date-mday
+  full_date: '{{date_fullyear}} - {{date_month}} - {{date_mday}}'
+  # full-time      = partial-time time-offset
+  full_time: '{{partial_time}} {{time_offset}}'
+  # offset-date-time = full-date T|%20 full-time
+  offset_date_time: '{{full_date}} [tT ] {{full_time}}'
+  # local-date-time = full-date T|%20 partial-time
+  local_date_time: '{{full_date}} [tT ] {{partial_time}}'
+  # local-date = full-date
+  local_date: '{{full_date}}'
+  # local-time = partial-time
+  local_time: '{{partial_time}}'
+
+contexts:
+  main:
+    - match: '^{{ws}}'
+      # Ignore leading whitespace for all expressions.
+    - include: comments
+    - include: tables
+    - include: keyval
+    - include: illegal
+
+  illegal:
+    - match: (.*)
+      # Invalid things -> everything unmatched
+      captures:
+        1: invalid.illegal.toml
+
+  comments:
+    - match: '{{ws}}((#).*)'
+      captures:
+        1: comment.line.number-sign.toml
+        2: punctuation.definition.comment.toml
+
+  data-types:
+    - include: inline-table
+    - include: array
+    - include: string
+    - include: date-time
+    - include: float
+    - include: integer
+    - include: boolean
+    - match: '{{ws}}$'
+      # Don't show an incomplete line as invalid to avoid frequent red
+      # highlighting while typing.
+      pop: true
+    - match: '\w+|.'
+      scope: invalid.illegal.value.toml
+      pop: true
+
+  boolean:
+    - match: (true|false)
+      captures:
+        1: constant.language.toml
+      pop: true
+
+  integer:
+    - match: |-
+        (?x)
+          (?<!\w)
+            {{hex_int}}
+            |{{oct_int}}
+            |{{bin_int}}
+            |{{integer}}
+          (?!\w)
+      captures:
+        0: constant.numeric.integer.toml
+        1: keyword.operator.arithmetic.toml
+      pop: true
+
+  float:
+    # float = float-int-part ( exp / frac [ exp ] )
+    # float =/ special-float
+    # special-float = [ minus / plus ] ( inf / nan )
+    # float-int-part = dec-int
+    - match: |-
+        (?x)
+          (?<!\w)
+            {{integer}}
+            (?: {{frac}} | (?: {{frac}} {{exp}} ) | {{exp}} )
+          (?!\w)
+      captures:
+        0: constant.numeric.float.toml
+        1: keyword.operator.arithmetic.toml
+      pop: true
+    - match: '(?<!\w)([+-])?(inf|nan)(?!\w)'
+      captures:
+        0: constant.numeric.float.toml
+        1: keyword.operator.arithmetic.toml
+      pop: true
+
+  date-time:
+    - match: '(?x) {{date_time}}'
+      scope: constant.other.datetime.toml
+      pop: true
+
+  string:
+    - match: "'''"
+      # multi-line literal string (no escape sequences)
+      scope: punctuation.definition.string.begin.toml
+      set:
+        - meta_scope: string.quoted.triple.literal.block.toml
+        - match: "'''"
+          scope: punctuation.definition.string.end.toml
+          pop: true
+    - match: '"""'
+      # multi-line basic string
+      scope: punctuation.definition.string.begin.toml
+      set:
+        - meta_scope: string.quoted.triple.basic.block.toml
+        - match: '"""'
+          scope: punctuation.definition.string.end.toml
+          pop: true
+        - include: string-escape
+    - include: basic-string
+    - include: literal-string
+
+  basic-string:
+    - match: '"'
+      scope: punctuation.definition.string.begin.toml
+      set:
+        - meta_scope: string.quoted.double.basic.toml
+        - include: string-escape
+        - match: '"'
+          scope: punctuation.definition.string.end.toml
+          pop: true
+        - match: '\n'
+          scope: invalid.illegal.string.non-terminated.toml
+          pop: true
+
+  string-escape:
+    - match: '\\(?:[btnfr"\\]|u\h{4}|U\h{8})'
+      scope: constant.character.escape.toml
+    - match: '\\.'
+      scope: invalid.illegal.string.escape.toml
+
+  literal-string:
+    - match: '('')[^'']*('')'
+      # There is ambiguity in what is allowed in a literal string.
+      # See: https://github.com/toml-lang/toml/issues/473
+      scope: string.quoted.single.literal.toml
+      captures:
+        1: punctuation.definition.string.begin.toml
+        2: punctuation.definition.string.end.toml
+      pop: true
+
+  array:
+    - match: '\['
+      scope: punctuation.definition.array.begin.toml
+      set: [maybe-empty-array, maybe-array-comments]
+
+  maybe-empty-array:
+    - match: ']'
+      scope: punctuation.definition.array.end.toml
+      pop: true
+    - match: ''
+      set: [array-sep, data-types]
+
+  array-sep:
+    - match: '{{wsnl}}'
+    - include: comments
+    - match: ']'
+      scope: punctuation.definition.array.end.toml
+      pop: true
+    - match: ','
+      scope: punctuation.separator.array.toml
+      set:
+        - match: '{{wsnl}}'
+        - include: comments
+        - match: ']'
+          scope: punctuation.definition.array.end.toml
+          pop: true
+        - match: '(?=[^\n])'
+          set: [array-sep, data-types]
+    - match: '\w+|.'
+      scope: invalid.illegal.array.toml
+
+  maybe-array-comments:
+    - match: '{{wsnl}}'
+    - include: comments
+    - match: '(?=[^\n])'
+      pop: true
+
+  inline-table:
+    - match: '\{'
+      scope: punctuation.definition.inline-table.begin.toml
+      set:
+        - match: '{{wsnl}}'
+        - include: comments
+        - match: '\}'
+          # Empty table.
+          scope: punctuation.definition.inline-table.end.toml
+          pop: true
+        - match: '(?=\S)'
+          set: [inline-keyval-sep, key]
+
+  inline-keyval-sep:
+    - match: '{{ws}}(=){{ws}}'
+      captures:
+        1: punctuation.definition.key-value.toml
+      set:
+        - match: '\}'
+          scope: invalid.illegal.inline-sep.toml
+          pop: true
+        - match: '(?=\S)'
+          set: [inline-table-keyvals, data-types]
+    - match: '(?=\w+|.)'
+      scope: invalid.illegal.inline-sep.toml
+      pop: true
+
+  inline-table-keyvals:
+    - match: '{{wsnl}}'
+    - include: comments
+    - match: '\}'
+      scope: punctuation.definition.inline-table.end.toml
+      pop: true
+    - match: ','
+      scope: punctuation.separator.inline-table.toml
+      set:
+        - match: '{{wsnl}}'
+        - include: comments
+        - match: '\}'
+          scope: punctuation.definition.inline-table.end.toml
+          pop: true
+        - match: '(?=\S)'
+          set: [inline-keyval-sep, key]
+    - match: '(?=\w+|.)'
+      scope: invalid.illegal.inline-key.toml
+      pop: true
+
+  keyval:
+    - match: '{{peek_key_start}}'
+      push: [keyval-sep, key]
+
+  keyval-sep:
+    - match: '{{ws}}(=){{ws}}'
+      captures:
+        # This could arguably be keyword.operator.assignment.toml, but since
+        # Monokai uses the same color for non-C sources with entity.name.tag,
+        # it doesn't have the appropriate visual distinction.
+        1: punctuation.definition.key-value.toml
+      set: [maybe-comment-eol, data-types]
+    - match: '{{ws}}$'
+      # Don't show an incomplete line as invalid to avoid flickering.
+      pop: true
+    - match: '.+$'
+      scope: invalid.illegal.keyval.toml
+      pop: true
+
+  key:
+    - meta_scope: meta.tag.key.toml
+    - match: '{{peek_key_start}}'
+      push: [maybe-dot-key, key-simple]
+    - match: '(?={{ws}}=)'
+      pop: true
+    - match: '{{ws}}$'
+      # Early exit to avoid errors while typing.
+      pop: true
+    - match: '.'
+      scope: invalid.illegal.key.toml
+      pop: true
+
+  key-simple:
+    - match: '[A-Za-z0-9_-]+'
+      scope: entity.name.tag.toml
+      pop: true
+    - include: key-quoted
+    - match: '\S+'
+      scope: invalid.illegal.key.toml
+      pop: true
+
+  key-quoted:
+    - include: basic-string
+    - include: literal-string
+
+  maybe-dot-key:
+    - match: '{{dot_peek_key}}'
+      captures:
+        1: punctuation.separator.key.toml
+      push: key-simple
+    - match: '(?={{ws}}(?:=|$))'
+      pop: true
+    - match: '.'
+      scope: invalid.illegal.key.toml
+      pop: true
+
+  maybe-comment-eol:
+    - include: comments
+    - match: '$'
+      pop: true
+    - match: '.+'
+      # This also highlights trailing whitespece.  Although that is valid
+      # TOML, it doesn't seem bad to me.  If that's annoying, change this
+      # to '[^ \n]+'.
+      scope: invalid.illegal.trailing.toml
+      pop: true
+
+  tables:
+    - match: '\[?\[{{ws}}\]\]?'
+      scope: invalid.illegal.table.toml
+
+    - match: '(\[\[){{ws}}'
+      # Array table.  Same as std-table with double-brackets.
+      captures:
+        1: punctuation.definition.table.array.begin.toml
+      push: [maybe-comment-eol, table-array-name]
+
+    - match: '(\[){{ws}}'
+      # std-table = ws "[" ws key (ws "." ws key)* ws "]" ws comment?
+      captures:
+        1: punctuation.definition.table.begin.toml
+      push: [maybe-comment-eol, table-name]
+
+  table-name:
+    - meta_content_scope: meta.tag.table.toml
+    - match: '{{ws}}(\])'
+      captures:
+        1: punctuation.definition.table.end.toml
+      pop: true
+    - include: table-name-inc
+
+  table-array-name:
+    - meta_content_scope: meta.tag.table.array.toml
+    - match: '{{ws}}(\]\])'
+      captures:
+        1: punctuation.definition.table.array.end.toml
+      pop: true
+    - include: table-name-inc
+
+  table-name-inc:
+    - match: '{{peek_key_start}}'
+      push: [maybe-dot-table-name, table-name-simple]
+    - match: '[^\]]+\]?'
+      scope: invalid.illegal.table.toml
+      pop: true
+
+  table-name-simple:
+    - match: '[A-Za-z0-9_-]+'
+      scope: entity.name.table.toml
+      pop: true
+    - include: key-quoted
+    - match: '.'
+      scope: invalid.illegal.table.toml
+      pop: true
+
+  maybe-dot-table-name:
+    - match: '{{dot_peek_key}}'
+      captures:
+        1: punctuation.separator.table.toml
+      push: table-name-simple
+    - match: '(?={{ws}}(?:\]|$))'
+      pop: true
+    - match: '.'
+      scope: invalid.illegal.table.toml
+      pop: true

--- a/res/syntaxes/nginx.sublime-syntax
+++ b/res/syntaxes/nginx.sublime-syntax
@@ -1,0 +1,437 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: nginx
+file_extensions:
+  - conf.erb
+  - conf
+  - nginx.conf
+  - mime.types
+  - fastcgi_params
+  - scgi_params
+  - uwsgi_params
+scope: source.nginx
+contexts:
+  main:
+    - match: \#.*
+      scope: comment.line.number-sign
+    - match: '\b(events) +\{'
+      captures:
+        1: storage.type.context.nginx
+      push:
+        - meta_scope: meta.context.events.nginx
+        - match: '\}'
+          pop: true
+        - include: main
+    - match: '\b(http) +\{'
+      captures:
+        1: storage.type.context.nginx
+      push:
+        - meta_scope: meta.context.http.nginx
+        - match: '\}'
+          pop: true
+        - include: main
+    - match: '\b(types) +\{'
+      captures:
+        1: storage.type.context.nginx
+      push:
+        - meta_scope: meta.context.types.nginx
+        - match: '\}'
+          pop: true
+        - include: main
+    - match: '\b(server) +\{'
+      captures:
+        1: storage.type.context.nginx
+      push:
+        - meta_scope: meta.context.server.nginx
+        - match: '\}'
+          pop: true
+        - include: main
+    - match: '\b(location) +[\^]?~[\*]? +(.*?)\{'
+      captures:
+        1: storage.type.context.location.nginx
+        2: string.regexp.nginx
+      push:
+        - meta_scope: meta.context.location.nginx
+        - match: '\}'
+          pop: true
+        - include: main
+    - match: '\b(location) +(.*?)\{'
+      captures:
+        1: storage.type.context.location.nginx
+        2: entity.name.context.location.nginx
+      push:
+        - meta_scope: meta.context.location.nginx
+        - match: '\}'
+          pop: true
+        - include: main
+    - match: '\b(upstream) +(.*?)\{'
+      captures:
+        1: storage.type.context.nginx
+        2: entity.name.context.location.nginx
+      push:
+        - meta_scope: meta.context.upstream.nginx
+        - match: '\}'
+          pop: true
+        - include: main
+    - match: \b(if) +\(
+      captures:
+        1: keyword.control.nginx
+      push:
+        - match: \)
+          pop: true
+        - include: values
+    - match: '\{'
+      push:
+        - meta_scope: meta.block.nginx
+        - match: '\}'
+          pop: true
+        - include: main
+    - match: \b(daemon|env|debug_points|error_log|include|lock_file|master_process|pid|ssl_engine|timer_resolution|user|worker_cpu_affinity|worker_priority|worker_processes|worker_rlimit_core|worker_rlimit_nofile|worker_rlimit_sigpending|working_directory)\b
+      captures:
+        1: keyword.directive.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(accept_mutex|accept_mutex_delay|debug_connection|devpoll_changes|devpoll_events|epoll_events|kqueue_changes|kqueue_events|multi_accept|rtsig_signo|rtsig_overflow_events|rtsig_overflow_test|rtsig_overflow_threshold|use|worker_connections)\b
+      captures:
+        1: keyword.directive.module.events.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(aio|alias|chunked_transfer_encoding|client_body_in_file_only|client_body_in_single_buffer|client_body_buffer_size|client_body_temp_path|client_body_timeout|client_header_buffer_size|client_header_timeout|client_max_body_size|connection_pool_size|default_type|directio|error_page|if_modified_since|internal|keepalive_disable|keepalive_timeout|keepalive_requests|large_client_header_buffers|limit_except|limit_rate|limit_rate_after|lingering_close|lingering_time|lingering_timeout|listen|log_not_found|log_subrequest|msie_padding|msie_refresh|open_file_cache|open_file_cache_errors|open_file_cache_min_uses|open_file_cache_valid|optimize_server_names|port_in_redirect|post_action|recursive_error_pages|request_pool_size|reset_timedout_connection|resolver|resolver_timeout|root|satisfy|satisfy_any|send_timeout|sendfile|server_name|server_name_in_redirect|server_names_hash_max_size|server_names_hash_bucket_size|server_tokens|tcp_nodelay|tcp_nopush|try_files|types\ |underscores_in_hashes|variables_hash_bucket_size|variables_hash_max_size|types_hash_max_size)\b
+      captures:
+        1: keyword.directive.module.http.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(set_real_ip_from|real_ip_recursive|real_ip_header)\b
+      captures:
+        1: keyword.directive.module.http.realip.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(allow|deny)\b
+      captures:
+        1: keyword.directive.module.http.access.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(auth_basic|auth_basic_user_file)\b
+      captures:
+        1: keyword.directive.module.http.auth_basic.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(autoindex|autoindex_exact_size|autoindex_localtime)\b
+      captures:
+        1: keyword.directive.module.http.autoindex.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(ancient_browser|ancient_browser_value|modern_browser|modern_browser_value)\b
+      captures:
+        1: keyword.directive.module.http.browser.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(charset|charset_map|override_charset|source_charset)\b
+      captures:
+        1: keyword.directive.module.http.charset.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(empty_gif)\b
+      captures:
+        1: keyword.directive.module.http.empty_gif.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(fastcgi_bind|fastcgi_buffer_size|fastcgi_buffers|fastcgi_cache|fastcgi_cache_key|fastcgi_cache_path|fastcgi_cache_methods|fastcgi_cache_min_uses|fastcgi_cache_use_stale|fastcgi_cache_valid|fastcgi_connect_timeout|fastcgi_index|fastcgi_hide_header|fastcgi_ignore_client_abort|fastcgi_ignore_headers|fastcgi_intercept_errors|fastcgi_max_temp_file_size|fastcgi_no_cache|fastcgi_next_upstream|fastcgi_param|fastcgi_pass|fastcgi_pass_header|fastcgi_pass_request_body|fastcgi_pass_request_headers|fastcgi_read_timeout|fastcgi_redirect_errors|fastcgi_send_timeout|fastcgi_split_path_info|fastcgi_store|fastcgi_store_access|fastcgi_temp_path)\b
+      captures:
+        1: keyword.directive.module.http.fastcgi.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(geo)\b
+      captures:
+        1: keyword.directive.module.http.geo.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(gzip|gzip_buffers|gzip_comp_level|gzip_disable|gzip_http_version|gzip_min_length|gzip_proxied|gzip_types|gzip_vary)\b
+      captures:
+        1: keyword.directive.module.http.gzip.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(gzip_static|gzip_disable|gzip_http_version|gzip_proxied|gzip_vary)\b
+      captures:
+        1: keyword.directive.module.http.gzip_static.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(add_header|expires)\b
+      captures:
+        1: keyword.directive.module.http.headers.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(index)\b
+      captures:
+        1: keyword.directive.module.http.index.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(limit_req_log_level|limit_req_zone|limit_req)\b
+      scope: punctuation.definition.variable
+      captures:
+        1: keyword.directive.module.http.limit_req.nginx
+    - match: \b(limit_zone|limit_conn|limit_conn_log_level)\b
+      captures:
+        1: keyword.directive.module.http.limit_zone.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(limit_conn_zone|limit_conn|limit_conn_log_level)\b
+      captures:
+        1: keyword.directive.module.http.limit_conn.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(access_log|log_format|open_log_file_cache)\b
+      captures:
+        1: keyword.directive.module.http.log.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: '\b(map) +(\$[A-Za-z0-9\_]+) +(\$[A-Za-z0-9\_]+) *\{'
+      captures:
+        1: storage.type.context.nginx
+        2: variable.other.nginx
+        3: variable.other.nginx
+      push:
+        - meta_scope: meta.context.map.nginx
+        - match: '\}'
+          pop: true
+        - include: values
+        - match: ;
+          scope: punctuation.definition.map.nginx
+        - match: \#.*
+          scope: comment.line.number-sign
+    - match: \b(map_hash_max_size|map_hash_bucket_size)\b
+      captures:
+        1: keyword.directive.module.http.map.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(memcached_pass|memcached_connect_timeout|memcached_read_timeout|memcached_send_timeout|memcached_buffer_size|memcached_next_upstream)\b
+      captures:
+        1: keyword.directive.module.http.memcached.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(proxy_bind|proxy_buffer_size|proxy_buffering|proxy_buffers|proxy_busy_buffers_size|proxy_cache|proxy_cache_bypass|proxy_cache_key|proxy_cache_methods|proxy_cache_min_uses|proxy_cache_path|proxy_cache_use_stale|proxy_cache_valid|proxy_connect_timeout|proxy_headers_hash_bucket_size|proxy_headers_hash_max_size|proxy_hide_header|proxy_ignore_client_abort|proxy_ignore_headers|proxy_intercept_errors|proxy_max_temp_file_size|proxy_method|proxy_next_upstream|proxy_no_cache|proxy_pass|proxy_http_version|proxy_pass_header|proxy_pass_request_body|proxy_pass_request_headers|proxy_redirect|proxy_read_timeout|proxy_redirect_errors|proxy_send_lowat|proxy_send_timeout|proxy_set_body|proxy_set_header|proxy_ssl_session_reuse|proxy_store|proxy_store_access|proxy_temp_file_write_size|proxy_temp_path|proxy_upstream_fail_timeout|proxy_upstream_max_fails)\b
+      captures:
+        1: keyword.directive.module.http.proxy.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(valid_referers)\b
+      captures:
+        1: keyword.directive.module.http.referer.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(rewrite_log|set|uninitialized_variable_warn)\b
+      captures:
+        1: keyword.directive.module.http.rewrite.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(break|return)\b
+      captures:
+        1: support.function.module.http.rewrite.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(rewrite)\b *(".+?(?<!\\)"|'.+?(?<!\\)'|((.+?)(?<!\\)\s))
+      captures:
+        1: keyword.directive.module.http.rewrite.nginx
+        2: string.regexp.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(scgi_bind|scgi_buffer_size|scgi_buffering|scgi_buffers|scgi_busy_buffers_size|scgi_cache|scgi_cache_bypass|scgi_cache_key|scgi_cache_methods|scgi_cache_min_uses|scgi_cache_path|scgi_cache_use_stale|scgi_cache_valid|scgi_connect_timeout|scgi_hide_header|scgi_ignore_client_abort|scgi_ignore_headers|scgi_intercept_errors|scgi_max_temp_file_size|scgi_next_upstream|scgi_no_cache|scgi_param|scgi_pass|scgi_pass_header|scgi_pass_request_body|scgi_pass_request_headers|scgi_read_timeout|scgi_send_timeout|scgi_store|scgi_store_access|scgi_temp_file_write_size|scgi_temp_path)\b
+      captures:
+        1: keyword.directive.module.http.scgi.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(split_clients)\b
+      captures:
+        1: keyword.directive.module.http.split_clients.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(ssi|ssi_silent_errors|ssi_types|ssi_value_length)\b
+      captures:
+        1: keyword.directive.module.http.ssi.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(ssl|ssl_certificate|ssl_certificate_key|ssl_client_certificate|ssl_dhparam|ssl_ciphers|ssl_crl|ssl_prefer_server_ciphers|ssl_protocols|ssl_verify_client|ssl_verify_depth|ssl_session_cache|ssl_session_timeout|ssl_engine)\b
+      captures:
+        1: keyword.directive.module.http.ssl.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(ip_hash|server)\b
+      captures:
+        1: keyword.directive.module.http.upstream.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(userid|userid_domain|userid_expires|userid_name|userid_p3p|userid_path|userid_service)\b
+      captures:
+        1: keyword.directive.module.http.userid.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: \b(uwsgi_bind|uwsgi_buffer_size|uwsgi_buffering|uwsgi_buffers|uwsgi_busy_buffers_size|uwsgi_cache|uwsgi_cache_bypass|uwsgi_cache_key|uwsgi_cache_methods|uwsgi_cache_min_uses|uwsgi_cache_path|uwsgi_cache_use_stale|uwsgi_cache_valid|uwsgi_connect_timeout|uwsgi_hide_header|uwsgi_ignore_client_abort|uwsgi_ignore_headers|uwsgi_intercept_errors|uwsgi_max_temp_file_size|uwsgi_modifier1|uwsgi_modifier2|uwsgi_next_upstream|uwsgi_no_cache|uwsgi_param|uwsgi_pass|uwsgi_pass_header|uwsgi_pass_request_body|uwsgi_pass_request_headers|uwsgi_read_timeout|uwsgi_send_timeout|uwsgi_store|uwsgi_store_access|uwsgi_string|uwsgi_temp_file_write_size|uwsgi_temp_path)\b
+      captures:
+        1: keyword.directive.module.http.uwsgi.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: '\b.*_by_lua_block\s+\{'
+      push: Packages/Lua/Lua.sublime-syntax
+      with_prototype:
+        - match: '^\s*\}'
+          pop: 3
+    - match: '\b([a-zA-Z0-9\_]+)\s+'
+      captures:
+        1: keyword.directive.module.unsupported.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: (;|$)
+          pop: true
+        - include: values
+    - match: \b(stub_status)\b
+      captures:
+        1: keyword.directive.module.http.stub_status.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+    - match: '\b([a-z]+\/[a-z0-9\-\.\+]+)\b'
+      captures:
+        1: keyword.directive.module.http.nginx
+      push:
+        - meta_scope: punctuation.definition.variable
+        - match: ;
+          pop: true
+        - include: values
+  values:
+    - include: variables
+    - match: '[\t ]([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|[0-9a-f:]+)(\/[0-9]{2})?(?=[\t ;])'
+      captures:
+        1: string.ipaddress.nginx
+        2: constant.numeric.cidr.nginx
+    - match: '[\t ](=?[0-9][0-9\.]*[bBkKmMgGtTsShHdD]?)(?=[\t ;])'
+      captures:
+        1: constant.numeric.nginx
+    - match: '[\t ](on|off|true|false)(?=[\t ;])'
+      scope: constant.language.nginx
+    - match: '[\t ](kqueue|rtsig|epoll|\/dev\/poll|select|poll|eventport|max|all|default_server|default|main|crit|error|debug|warn|notice|last)(?=[\t ;])'
+      scope: constant.language.nginx
+    - match: \\.*\ |\~\*|\~|\!\~\*|\!\~
+      scope: string.regexp.nginx
+    - match: \^.*?\$
+      scope: string.regexp.nginx
+    - match: '"'
+      push:
+        - meta_scope: string.quoted.double.nginx
+        - match: '"'
+          pop: true
+        - match: \\"
+          scope: constant.character.escape.nginx
+        - include: variables
+    - match: "'"
+      push:
+        - meta_scope: string.quoted.single.nginx
+        - match: "'"
+          pop: true
+        - match: \\'
+          scope: constant.character.escape.nginx
+        - include: variables
+  variables:
+    - match: '(\$[A-Za-z0-9\_]+)\b'
+      scope: variable.other.nginx

--- a/src/ui/screens/readerscreen.rs
+++ b/src/ui/screens/readerscreen.rs
@@ -210,7 +210,11 @@ impl AppScreen for ReaderScreen {
         frame.render_widget(date, contentlayout[2]);
 
         // Content
-        let text = tuimarkdown::from_str(&current_entry.text, Some(theme.clone()));
+        let text = tuimarkdown::from_str(
+            &current_entry.text,
+            Some(theme.clone()),
+            contentlayout[3].width,
+        );
         let textheight = text.height() as usize;
 
         // This is a workaround to get more or less the amount of wrapped lines, to be used on the

--- a/src/ui/tools/styles.rs
+++ b/src/ui/tools/styles.rs
@@ -141,6 +141,18 @@ pub fn link(theme: Option<&Theme>) -> Style {
         .add_modifier(Modifier::UNDERLINED)
 }
 
+pub fn heading_meta(theme: Option<&Theme>) -> Style {
+    let meta_color = if let Some(t) = theme {
+        t.base[0x04]
+    } else {
+        0x888888
+    };
+
+    Style::new()
+        .fg(Color::from_u32(meta_color))
+        .add_modifier(Modifier::DIM)
+}
+
 pub fn metadata(theme: Option<&Theme>) -> Style {
     let metadata_color = if let Some(t) = theme {
         t.base[0x0a]

--- a/src/ui/tools/tuimarkdown.rs
+++ b/src/ui/tools/tuimarkdown.rs
@@ -12,7 +12,6 @@ use pulldown_cmark::{
 };
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span, Text};
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use syntect::{
     easy::HighlightLines,
     highlighting::ThemeSet,
@@ -20,6 +19,7 @@ use syntect::{
     util::{LinesWithEndings, as_24_bit_terminal_escaped},
 };
 use tracing::{debug, instrument, warn};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::core::library::settings::theme::Theme;
 use crate::ui::tools::styles;
@@ -547,12 +547,7 @@ where
                 let dashes = inner_width - lang_space;
                 let left = dashes / 2;
                 let right = dashes - left;
-                let top = format!(
-                    "┌{} {} {}┐",
-                    "─".repeat(left),
-                    lang,
-                    "─".repeat(right + 2)
-                );
+                let top = format!("┌{} {} {}┐", "─".repeat(left), lang, "─".repeat(right + 2));
                 self.push_line(Line::styled(top, code_style));
             } else {
                 let top = format!("┌{}┐", "─".repeat(box_width.saturating_sub(2)));
@@ -829,7 +824,8 @@ mod tests {
                 Hello
                 World
             "},
-                None, 80
+                None,
+                80
             ),
             Text::from_iter([
                 Line::from("Hello").style(styles::p(None)),
@@ -847,7 +843,8 @@ mod tests {
 
                 Paragraph 2
             "},
-                None, 80
+                None,
+                80
             ),
             Text::from_iter([
                 Line::from("Paragraph 1").style(styles::p(None)),
@@ -868,7 +865,8 @@ mod tests {
 
                 Paragraph 2
             "},
-                None, 80
+                None,
+                80
             ),
             Text::from_iter([
                 Line::from("Paragraph 1").style(styles::p(None)),
@@ -892,7 +890,8 @@ mod tests {
                 ##### Heading 5
                 ###### Heading 6
             "},
-                None, 80
+                None,
+                80
             ),
             Text::from_iter([
                 Line::from_iter(["# ", "Heading 1"]).style(styles::h1(None)),
@@ -939,7 +938,8 @@ mod tests {
 
                 > Blockquote
             "},
-                None, 80
+                None,
+                80
             ),
             Text::from_iter([
                 Line::from("Hello, world!").style(styles::blockquote(None)),
@@ -964,7 +964,8 @@ mod tests {
                 > Blockquote 1
                 > Blockquote 2
             "},
-                None, 80
+                None,
+                80
             ),
             Text::from_iter([
                 Line::from_iter([">", " ", "Blockquote 1"]).style(styles::blockquote(None)),
@@ -982,7 +983,8 @@ mod tests {
                 >
                 > Blockquote 2
             "},
-                None, 80
+                None,
+                80
             ),
             Text::from_iter([
                 Line::from_iter([">", " ", "Blockquote 1"]).style(styles::blockquote(None)),
@@ -1001,7 +1003,8 @@ mod tests {
 
                 > Blockquote 2
             "},
-                None, 80
+                None,
+                80
             ),
             Text::from_iter([
                 Line::from_iter([">", " ", "Blockquote 1"]).style(styles::blockquote(None)),
@@ -1019,7 +1022,8 @@ mod tests {
                 > Blockquote 1
                 >> Nested Blockquote
             "},
-                None, 80
+                None,
+                80
             ),
             Text::from_iter([
                 Line::from_iter([">", " ", "Blockquote 1"]).style(styles::blockquote(None)),
@@ -1037,7 +1041,8 @@ mod tests {
                 indoc! {"
                 - List item 1
             "},
-                None, 80
+                None,
+                80
             ),
             Text::from(Line::from_iter([
                 Span::from("\u{a0}\u{a0}• ").style(styles::list_item(None)),
@@ -1054,7 +1059,8 @@ mod tests {
                 - List item 1
                 - List item 2
             "},
-                None, 80
+                None,
+                80
             ),
             Text::from_iter([
                 Line::from_iter([
@@ -1077,7 +1083,8 @@ mod tests {
                 1. List item 1
                 2. List item 2
             "},
-                None, 80
+                None,
+                80
             ),
             Text::from_iter([
                 Line::from_iter([
@@ -1100,7 +1107,8 @@ mod tests {
                 - List item 1
                   - Nested list item 1
             "},
-                None, 80
+                None,
+                80
             ),
             Text::from_iter([
                 Line::from_iter([
@@ -1122,7 +1130,8 @@ mod tests {
                 - [ ] Incomplete
                 - [x] Complete
             "},
-            None, 80,
+            None,
+            80,
         );
         // Just verify it parses without error and has the right number of lines
         assert_eq!(result.lines.len(), 2);
@@ -1204,7 +1213,8 @@ mod tests {
 
                 Body
             "},
-                None, 80
+                None,
+                80
             ),
             Text::from_iter([
                 Line::from("---").style(Style::new().fg(Color::Rgb(255, 255, 255))),

--- a/src/ui/tools/tuimarkdown.rs
+++ b/src/ui/tools/tuimarkdown.rs
@@ -348,7 +348,8 @@ where
     fn text(&mut self, text: CowStr<'a>) {
         if let Some(highlighter) = &mut self.code_highlighter {
             let set = self.code_syntax_set.unwrap();
-            let text: Text = LinesWithEndings::from(&text)
+            let expanded = text.replace('\t', "  ");
+            let text: Text = LinesWithEndings::from(&expanded)
                 .filter_map(|line| highlighter.highlight_line(line, set).ok())
                 .filter_map(|part| as_24_bit_terminal_escaped(&part, false).into_text().ok())
                 .flatten()
@@ -365,7 +366,7 @@ where
             let code_style = styles::code(self.theme.as_ref());
             for line in text.lines() {
                 self.code_block_lines
-                    .push(Line::styled(line.to_string(), code_style));
+                    .push(Line::styled(line.replace('\t', "  "), code_style));
             }
             self.needs_newline = false;
             return;

--- a/src/ui/tools/tuimarkdown.rs
+++ b/src/ui/tools/tuimarkdown.rs
@@ -278,10 +278,13 @@ where
     }
 
     fn end_heading(&mut self) {
-        if let Some(meta) = self.heading_meta.take()
-            && let Some(suffix) = meta.to_suffix()
-        {
-            self.push_span(Span::styled(suffix, Style::new().dim()));
+        if let Some(meta) = self.heading_meta.take() {
+            if let Some(suffix) = meta.to_suffix() {
+                self.push_span(Span::styled(
+                    suffix,
+                    styles::heading_meta(self.theme.as_ref()),
+                ));
+            }
         }
         self.needs_newline = true
     }
@@ -688,6 +691,24 @@ mod tests {
                 Line::default(),
                 Line::from_iter(["###### ", "Heading 6"]).style(styles::h6(None)),
             ])
+        );
+    }
+
+    #[rstest]
+    fn heading_attributes(_with_tracing: DefaultGuard) {
+        let h1 = styles::h1(None);
+        let meta = styles::heading_meta(None);
+
+        assert_eq!(
+            from_str("# Heading {#title .primary data-kind=doc}", None),
+            Text::from(
+                Line::from_iter([
+                    Span::from("# "),
+                    Span::from("Heading"),
+                    Span::styled(" {#title .primary data-kind=doc}", meta),
+                ])
+                .style(h1)
+            )
         );
     }
 

--- a/src/ui/tools/tuimarkdown.rs
+++ b/src/ui/tools/tuimarkdown.rs
@@ -15,7 +15,7 @@ use ratatui::text::{Line, Span, Text};
 use syntect::{
     easy::HighlightLines,
     highlighting::ThemeSet,
-    parsing::SyntaxSet,
+    parsing::{SyntaxDefinition, SyntaxSet, SyntaxSetBuilder},
     util::{LinesWithEndings, as_24_bit_terminal_escaped},
 };
 use tracing::{debug, instrument, warn};
@@ -104,6 +104,9 @@ struct TextWriter<'a, I> {
     /// Used to highlight code blocks, set when  a codeblock is encountered
     code_highlighter: Option<HighlightLines<'a>>,
 
+    /// The [`SyntaxSet`] that the current code_highlighter's syntax came from.
+    code_syntax_set: Option<&'static SyntaxSet>,
+
     /// Current list index as a stack of indices.
     list_indices: Vec<Option<u64>>,
 
@@ -127,6 +130,25 @@ struct TextWriter<'a, I> {
 }
 
 static SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(SyntaxSet::load_defaults_newlines);
+static EXTRA_SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(|| {
+    let mut builder = SyntaxSetBuilder::new();
+    builder.add_plain_text_syntax();
+    const FILES: &[&str] = &[
+        include_str!("../../../res/syntaxes/TOML.sublime-syntax"),
+        include_str!("../../../res/syntaxes/Dockerfile.sublime-syntax"),
+        include_str!("../../../res/syntaxes/CMake.sublime-syntax"),
+        include_str!("../../../res/syntaxes/INI.sublime-syntax"),
+        include_str!("../../../res/syntaxes/DotENV.sublime-syntax"),
+        include_str!("../../../res/syntaxes/GraphQL.sublime-syntax"),
+        include_str!("../../../res/syntaxes/nginx.sublime-syntax"),
+    ];
+    for src in FILES {
+        if let Ok(def) = SyntaxDefinition::load_from_str(src, true, None) {
+            builder.add(def);
+        }
+    }
+    builder.build()
+});
 static THEME_SET: LazyLock<ThemeSet> = LazyLock::new(ThemeSet::load_defaults);
 
 impl<'a, I> TextWriter<'a, I>
@@ -143,6 +165,7 @@ where
             list_indices: vec![],
             needs_newline: false,
             code_highlighter: None,
+            code_syntax_set: None,
             link: None,
             image: None,
             heading_meta: None,
@@ -307,8 +330,9 @@ where
 
     fn text(&mut self, text: CowStr<'a>) {
         if let Some(highlighter) = &mut self.code_highlighter {
+            let set = self.code_syntax_set.unwrap();
             let text: Text = LinesWithEndings::from(&text)
-                .filter_map(|line| highlighter.highlight_line(line, &SYNTAX_SET).ok())
+                .filter_map(|line| highlighter.highlight_line(line, set).ok())
                 .filter_map(|part| as_24_bit_terminal_escaped(&part, false).into_text().ok())
                 .flatten()
                 .collect();
@@ -474,19 +498,45 @@ where
 
     #[instrument(level = "trace", skip(self))]
     fn set_code_highlighter(&mut self, lang: &str) {
-        if let Some(syntax) = SYNTAX_SET.find_syntax_by_token(lang) {
-            debug!("Starting code block with syntax: {:?}", lang);
-            let theme = &THEME_SET.themes["base16-ocean.dark"];
-            let highlighter = HighlightLines::new(syntax, theme);
-            self.code_highlighter = Some(highlighter);
-        } else {
-            warn!("Could not find syntax for code block: {:?}", lang);
+        let resolved = match lang {
+            "shell" => "sh",
+            "bash" => "sh",
+            "yaml" => "yml",
+            "docker" => "Dockerfile",
+            "dockerfile" => "Dockerfile",
+            "Containerfile" => "Dockerfile",
+            "Caddyfile" => "nginx",
+            other => other,
+        };
+        let maybe_pair = SYNTAX_SET
+            .find_syntax_by_token(resolved)
+            .map(|s| (s, &*SYNTAX_SET))
+            .or_else(|| {
+                EXTRA_SYNTAX_SET
+                    .find_syntax_by_token(resolved)
+                    .map(|s| (s, &*EXTRA_SYNTAX_SET))
+            });
+        match maybe_pair {
+            Some((syntax, set)) => {
+                debug!(
+                    "Starting code block with syntax: {:?} (resolved: {:?})",
+                    lang, resolved
+                );
+                let theme = &THEME_SET.themes["base16-ocean.dark"];
+                let highlighter = HighlightLines::new(syntax, theme);
+                self.code_highlighter = Some(highlighter);
+                self.code_syntax_set = Some(set);
+            }
+            None => {
+                warn!("Could not find syntax for code block: {:?}", lang);
+            }
         }
     }
 
     #[instrument(level = "trace", skip(self))]
     fn clear_code_highlighter(&mut self) {
         self.code_highlighter = None;
+        self.code_syntax_set = None;
     }
 
     #[instrument(level = "trace", skip(self))]

--- a/src/ui/tools/tuimarkdown.rs
+++ b/src/ui/tools/tuimarkdown.rs
@@ -10,8 +10,9 @@ use itertools::{Itertools, Position};
 use pulldown_cmark::{
     BlockQuoteKind, CodeBlockKind, CowStr, Event, HeadingLevel, Options, Parser, Tag, TagEnd,
 };
-use ratatui::style::Style;
+use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span, Text};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use syntect::{
     easy::HighlightLines,
     highlighting::ThemeSet,
@@ -23,7 +24,7 @@ use tracing::{debug, instrument, warn};
 use crate::core::library::settings::theme::Theme;
 use crate::ui::tools::styles;
 
-pub fn from_str(input: &str, theme: Option<Theme>) -> Text<'_> {
+pub fn from_str(input: &str, theme: Option<Theme>, max_width: u16) -> Text<'_> {
     let mut options = Options::empty();
     options.insert(Options::ENABLE_STRIKETHROUGH);
     options.insert(Options::ENABLE_TASKLISTS);
@@ -32,7 +33,7 @@ pub fn from_str(input: &str, theme: Option<Theme>) -> Text<'_> {
     options.insert(Options::ENABLE_SUPERSCRIPT);
     options.insert(Options::ENABLE_SUBSCRIPT);
     let parser = Parser::new_ext(input, options);
-    let mut writer = TextWriter::new(parser, theme);
+    let mut writer = TextWriter::new(parser, theme, max_width);
     writer.run();
     writer.text
 }
@@ -125,6 +126,18 @@ struct TextWriter<'a, I> {
     /// True when last element requires a new line
     needs_newline: bool,
 
+    /// Buffer for highlighted code block lines before flushing.
+    code_block_lines: Vec<Line<'a>>,
+
+    /// The language identifier of the current code block.
+    code_block_lang: String,
+
+    /// Whether we are currently inside a code block (even without a highlighter).
+    in_codeblock: bool,
+
+    /// Maximum width of the rendered area (viewport width).
+    max_width: u16,
+
     /// bulletty Theme
     theme: Option<Theme>,
 }
@@ -155,7 +168,7 @@ impl<'a, I> TextWriter<'a, I>
 where
     I: Iterator<Item = Event<'a>>,
 {
-    fn new(iter: I, theme: Option<Theme>) -> Self {
+    fn new(iter: I, theme: Option<Theme>, max_width: u16) -> Self {
         Self {
             iter,
             text: Text::default(),
@@ -170,6 +183,10 @@ where
             image: None,
             heading_meta: None,
             in_metadata_block: false,
+            code_block_lines: vec![],
+            code_block_lang: String::new(),
+            in_codeblock: false,
+            max_width,
             theme,
         }
     }
@@ -338,7 +355,17 @@ where
                 .collect();
 
             for line in text.lines {
-                self.text.push_line(line);
+                self.code_block_lines.push(line);
+            }
+            self.needs_newline = false;
+            return;
+        }
+
+        if self.in_codeblock {
+            let code_style = styles::code(self.theme.as_ref());
+            for line in text.lines() {
+                self.code_block_lines
+                    .push(Line::styled(line.to_string(), code_style));
             }
             self.needs_newline = false;
             return;
@@ -481,19 +508,71 @@ where
 
         self.set_code_highlighter(lang);
 
-        let span = Span::from(format!("```{lang}"));
-        self.push_line(span.into());
-        self.needs_newline = true;
+        self.code_block_lines.clear();
+        self.code_block_lang.clear();
+        self.code_block_lang.push_str(lang);
+        self.in_codeblock = true;
     }
 
     fn end_codeblock(&mut self) {
-        let span = Span::from("```");
-        self.push_line(span.into());
-        self.needs_newline = true;
+        self.in_codeblock = false;
+        self.flush_codeblock();
 
         self.line_styles.pop();
 
         self.clear_code_highlighter();
+    }
+
+    fn flush_codeblock(&mut self) {
+        let code_style = styles::code(self.theme.as_ref());
+        let bg = code_style.bg.unwrap_or(Color::Black);
+
+        let lines = std::mem::take(&mut self.code_block_lines);
+        let lang = std::mem::take(&mut self.code_block_lang);
+
+        let box_width = self.max_width as usize;
+        if box_width < 4 {
+            return;
+        }
+
+        let has_lang = !lang.is_empty();
+        let lang_width = UnicodeWidthStr::width(lang.as_str());
+
+        let inner_width = box_width.saturating_sub(4);
+
+        if has_lang {
+            let lang_space = lang_width + 2;
+            if inner_width >= lang_space {
+                let dashes = inner_width - lang_space;
+                let left = dashes / 2;
+                let right = dashes - left;
+                let top = format!(
+                    "┌{} {} {}┐",
+                    "─".repeat(left),
+                    lang,
+                    "─".repeat(right + 2)
+                );
+                self.push_line(Line::styled(top, code_style));
+            } else {
+                let top = format!("┌{}┐", "─".repeat(box_width.saturating_sub(2)));
+                self.push_line(Line::styled(top, code_style));
+            }
+        } else {
+            let top = format!("┌{}┐", "─".repeat(box_width.saturating_sub(2)));
+            self.push_line(Line::styled(top, code_style));
+        }
+
+        for line in lines {
+            let wrapped = wrap_code_line(line, inner_width, bg, code_style);
+            for wline in wrapped {
+                self.text.lines.push(wline);
+            }
+        }
+
+        let bottom = format!("└{}┘", "─".repeat(box_width.saturating_sub(2)));
+        self.push_line(Line::styled(bottom, code_style));
+
+        self.needs_newline = true;
     }
 
     #[instrument(level = "trace", skip(self))]
@@ -618,6 +697,92 @@ where
     }
 }
 
+fn split_str_at_width(s: &str, max_width: usize) -> (&str, &str) {
+    let mut width = 0;
+    for (i, c) in s.char_indices() {
+        let cw = UnicodeWidthChar::width(c).unwrap_or(0);
+        if width + cw > max_width {
+            return (&s[..i], &s[i..]);
+        }
+        width += cw;
+    }
+    (s, "")
+}
+
+fn fill_line(line: Line<'_>, inner_width: usize, bg: Color, code_style: Style) -> Line<'_> {
+    let line_width = line.width();
+    let padding = inner_width.saturating_sub(line_width);
+    let pad_bg = Style::new().bg(bg);
+    let mut spans: Vec<Span> = vec![Span::styled("│ ", code_style)];
+    for span in line.spans {
+        spans.push(Span::styled(span.content, span.style.bg(bg)));
+    }
+    if padding > 0 {
+        spans.push(Span::styled(" ".repeat(padding), pad_bg));
+    }
+    spans.push(Span::styled(" │", code_style));
+    Line::from(spans)
+}
+
+fn wrap_code_line<'a>(
+    mut line: Line<'a>,
+    inner_width: usize,
+    bg: Color,
+    code_style: Style,
+) -> Vec<Line<'a>> {
+    let line_width = line.width();
+    if inner_width == 0 {
+        return vec![fill_line(line, 0, bg, code_style)];
+    }
+    if line_width <= inner_width {
+        return vec![fill_line(line, inner_width, bg, code_style)];
+    }
+
+    let mut spans = std::mem::take(&mut line.spans);
+    let mut result = Vec::new();
+    let mut span_idx = 0;
+
+    while span_idx < spans.len() {
+        let mut current_spans: Vec<Span> = Vec::new();
+        let mut current_width = 0;
+
+        loop {
+            if span_idx >= spans.len() {
+                break;
+            }
+            let span = &spans[span_idx];
+            let style = span.style.bg(bg);
+            let span_width = span.width();
+            let remaining = inner_width.saturating_sub(current_width);
+
+            if span_width <= remaining {
+                current_spans.push(Span::styled(span.content.to_string(), style.clone()));
+                current_width += span_width;
+                span_idx += 1;
+            } else if remaining == 0 {
+                break;
+            } else {
+                let content = span.content.as_ref();
+                let (first, second) = split_str_at_width(content, remaining);
+                if !first.is_empty() {
+                    current_spans.push(Span::styled(first.to_string(), style.clone()));
+                }
+                spans[span_idx] = Span::styled(second.to_string(), style);
+                break;
+            }
+        }
+
+        result.push(fill_line(
+            Line::from(current_spans),
+            inner_width,
+            bg,
+            code_style,
+        ));
+    }
+
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use indoc::indoc;
@@ -644,13 +809,13 @@ mod tests {
 
     #[rstest]
     fn empty(_with_tracing: DefaultGuard) {
-        assert_eq!(from_str("", None), Text::default());
+        assert_eq!(from_str("", None, 80), Text::default());
     }
 
     #[rstest]
     fn paragraph_single(_with_tracing: DefaultGuard) {
         assert_eq!(
-            from_str("Hello, world!", None),
+            from_str("Hello, world!", None, 80),
             Text::from(Line::from("Hello, world!").style(styles::p(None)))
         );
     }
@@ -663,7 +828,7 @@ mod tests {
                 Hello
                 World
             "},
-                None
+                None, 80
             ),
             Text::from_iter([
                 Line::from("Hello").style(styles::p(None)),
@@ -681,7 +846,7 @@ mod tests {
 
                 Paragraph 2
             "},
-                None
+                None, 80
             ),
             Text::from_iter([
                 Line::from("Paragraph 1").style(styles::p(None)),
@@ -702,7 +867,7 @@ mod tests {
 
                 Paragraph 2
             "},
-                None
+                None, 80
             ),
             Text::from_iter([
                 Line::from("Paragraph 1").style(styles::p(None)),
@@ -726,7 +891,7 @@ mod tests {
                 ##### Heading 5
                 ###### Heading 6
             "},
-                None
+                None, 80
             ),
             Text::from_iter([
                 Line::from_iter(["# ", "Heading 1"]).style(styles::h1(None)),
@@ -750,7 +915,7 @@ mod tests {
         let meta = styles::heading_meta(None);
 
         assert_eq!(
-            from_str("# Heading {#title .primary data-kind=doc}", None),
+            from_str("# Heading {#title .primary data-kind=doc}", None, 80),
             Text::from(
                 Line::from_iter([
                     Span::from("# "),
@@ -773,7 +938,7 @@ mod tests {
 
                 > Blockquote
             "},
-                None
+                None, 80
             ),
             Text::from_iter([
                 Line::from("Hello, world!").style(styles::blockquote(None)),
@@ -785,7 +950,7 @@ mod tests {
     #[rstest]
     fn blockquote_single(_with_tracing: DefaultGuard) {
         assert_eq!(
-            from_str("> Blockquote", None),
+            from_str("> Blockquote", None, 80),
             Text::from(Line::from_iter([">", " ", "Blockquote"]).style(styles::blockquote(None)))
         );
     }
@@ -798,7 +963,7 @@ mod tests {
                 > Blockquote 1
                 > Blockquote 2
             "},
-                None
+                None, 80
             ),
             Text::from_iter([
                 Line::from_iter([">", " ", "Blockquote 1"]).style(styles::blockquote(None)),
@@ -816,7 +981,7 @@ mod tests {
                 >
                 > Blockquote 2
             "},
-                None
+                None, 80
             ),
             Text::from_iter([
                 Line::from_iter([">", " ", "Blockquote 1"]).style(styles::blockquote(None)),
@@ -835,7 +1000,7 @@ mod tests {
 
                 > Blockquote 2
             "},
-                None
+                None, 80
             ),
             Text::from_iter([
                 Line::from_iter([">", " ", "Blockquote 1"]).style(styles::blockquote(None)),
@@ -853,7 +1018,7 @@ mod tests {
                 > Blockquote 1
                 >> Nested Blockquote
             "},
-                None
+                None, 80
             ),
             Text::from_iter([
                 Line::from_iter([">", " ", "Blockquote 1"]).style(styles::blockquote(None)),
@@ -871,7 +1036,7 @@ mod tests {
                 indoc! {"
                 - List item 1
             "},
-                None
+                None, 80
             ),
             Text::from(Line::from_iter([
                 Span::from("\u{a0}\u{a0}• ").style(styles::list_item(None)),
@@ -888,7 +1053,7 @@ mod tests {
                 - List item 1
                 - List item 2
             "},
-                None
+                None, 80
             ),
             Text::from_iter([
                 Line::from_iter([
@@ -911,7 +1076,7 @@ mod tests {
                 1. List item 1
                 2. List item 2
             "},
-                None
+                None, 80
             ),
             Text::from_iter([
                 Line::from_iter([
@@ -934,7 +1099,7 @@ mod tests {
                 - List item 1
                   - Nested list item 1
             "},
-                None
+                None, 80
             ),
             Text::from_iter([
                 Line::from_iter([
@@ -956,7 +1121,7 @@ mod tests {
                 - [ ] Incomplete
                 - [x] Complete
             "},
-            None,
+            None, 80,
         );
         // Just verify it parses without error and has the right number of lines
         assert_eq!(result.lines.len(), 2);
@@ -965,7 +1130,7 @@ mod tests {
     #[rstest]
     fn strong(_with_tracing: DefaultGuard) {
         assert_eq!(
-            from_str("**Strong**", None),
+            from_str("**Strong**", None, 80),
             Text::from(Line::from("Strong".bold()).style(styles::p(None)))
         );
     }
@@ -973,7 +1138,7 @@ mod tests {
     #[rstest]
     fn emphasis(_with_tracing: DefaultGuard) {
         assert_eq!(
-            from_str("*Emphasis*", None),
+            from_str("*Emphasis*", None, 80),
             Text::from(Line::from("Emphasis".italic()).style(styles::p(None)))
         );
     }
@@ -981,7 +1146,7 @@ mod tests {
     #[rstest]
     fn strikethrough(_with_tracing: DefaultGuard) {
         assert_eq!(
-            from_str("~~Strikethrough~~", None),
+            from_str("~~Strikethrough~~", None, 80),
             Text::from(Line::from("Strikethrough".crossed_out()).style(styles::p(None)))
         );
     }
@@ -989,7 +1154,7 @@ mod tests {
     #[rstest]
     fn strong_emphasis(_with_tracing: DefaultGuard) {
         assert_eq!(
-            from_str("**Strong *emphasis***", None),
+            from_str("**Strong *emphasis***", None, 80),
             Text::from(
                 Line::from_iter(["Strong ".bold(), "emphasis".bold().italic()])
                     .style(styles::p(None))
@@ -1000,7 +1165,7 @@ mod tests {
     #[rstest]
     fn superscript(_with_tracing: DefaultGuard) {
         assert_eq!(
-            from_str("H ^2^ O", None),
+            from_str("H ^2^ O", None, 80),
             Text::from(
                 Line::from_iter([
                     Span::from("H "),
@@ -1015,7 +1180,7 @@ mod tests {
     #[rstest]
     fn subscript(_with_tracing: DefaultGuard) {
         assert_eq!(
-            from_str("H ~2~ O", None),
+            from_str("H ~2~ O", None, 80),
             Text::from(
                 Line::from_iter([
                     Span::from("H "),
@@ -1038,7 +1203,7 @@ mod tests {
 
                 Body
             "},
-                None
+                None, 80
             ),
             Text::from_iter([
                 Line::from("---").style(Style::new().fg(Color::Rgb(255, 255, 255))),
@@ -1053,7 +1218,7 @@ mod tests {
     #[rstest]
     fn link(_with_tracing: DefaultGuard) {
         assert_eq!(
-            from_str("[Link](https://example.com)", None),
+            from_str("[Link](https://example.com)", None, 80),
             Text::from(
                 Line::from_iter([
                     Span::from("Link"),
@@ -1071,7 +1236,7 @@ mod tests {
     #[rstest]
     fn image(_with_tracing: DefaultGuard) {
         assert_eq!(
-            from_str("![TestImage](/test.html)", None),
+            from_str("![TestImage](/test.html)", None, 80),
             Text::from_iter([
                 Line::default().style(styles::p(None)),
                 Line::from_iter([


### PR DESCRIPTION
I've been preparing this for some time. The renderer already supported code highlighting, but it wasn't being informed of which language that color was. I intended to implement that in `html2md-bulletty`, but I realized that this feature was recently implemented in `html2md`, which is the library that `html2md-bulletty` is based on.

Just downstreaming `html2md` did the job. So, to make it look even cool and easier to the eyes, I improved the rendering of code blocks. Now it's looking like this:

<img width="1723" height="1215" alt="image" src="https://github.com/user-attachments/assets/5e10e58b-6f4a-4d47-9a96-f59badd5f30a" />

There are still an issue I'd like to fix in the future: somehow there's ALWAYS one extra empty line when converting the code block to markdown. It might be due to my own changes to `html2md`. Thing for the future. :)