### PR TITLE
Add <P> style to readerscreen content container

### DIFF
--- a/src/ui/screens/readerscreen.rs
+++ b/src/ui/screens/readerscreen.rs
@@ -23,7 +23,7 @@ use crate::core::{
 };
 use crate::ui::screens::themedialog::ThemeDialog;
 use crate::ui::screens::urldialog::UrlDialog;
-use crate::ui::tools::tuimarkdown;
+use crate::ui::tools::{styles, tuimarkdown};
 
 use super::helpdialog::HelpDialog;
 
@@ -237,6 +237,7 @@ impl AppScreen for ReaderScreen {
 
         // Content Paragraph component
         let paragraph = Paragraph::new(text)
+            .style(styles::p(Some(&theme)))
             .scroll((self.scroll as u16, 0))
             .alignment(Alignment::Left)
             .wrap(Wrap { trim: true });

--- a/src/ui/tools/tuimarkdown.rs
+++ b/src/ui/tools/tuimarkdown.rs
@@ -318,13 +318,13 @@ where
     }
 
     fn end_heading(&mut self) {
-        if let Some(meta) = self.heading_meta.take() {
-            if let Some(suffix) = meta.to_suffix() {
-                self.push_span(Span::styled(
-                    suffix,
-                    styles::heading_meta(self.theme.as_ref()),
-                ));
-            }
+        if let Some(meta) = self.heading_meta.take()
+            && let Some(suffix) = meta.to_suffix()
+        {
+            self.push_span(Span::styled(
+                suffix,
+                styles::heading_meta(self.theme.as_ref()),
+            ));
         }
         self.needs_newline = true
     }
@@ -752,7 +752,7 @@ fn wrap_code_line<'a>(
             let remaining = inner_width.saturating_sub(current_width);
 
             if span_width <= remaining {
-                current_spans.push(Span::styled(span.content.to_string(), style.clone()));
+                current_spans.push(Span::styled(span.content.to_string(), style));
                 current_width += span_width;
                 span_idx += 1;
             } else if remaining == 0 {
@@ -761,7 +761,7 @@ fn wrap_code_line<'a>(
                 let content = span.content.as_ref();
                 let (first, second) = split_str_at_width(content, remaining);
                 if !first.is_empty() {
-                    current_spans.push(Span::styled(first.to_string(), style.clone()));
+                    current_spans.push(Span::styled(first.to_string(), style));
                 }
                 spans[span_idx] = Span::styled(second.to_string(), style);
                 break;


### PR DESCRIPTION
Fix for https://github.com/crocidb/bulletty/issues/196

Applies `ui::tools::styles::p` to the content container paragraph for the readerscreen
this way, if a line doesn't get styled specifically for whatever reason, it won't fallback to an unstyled text color.