### PR TITLE
feat: fetch feed updates in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93c1f86859c1af3d514fa19e8323147ff10ea98684e6c7b307912509f50e67b2"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +272,7 @@ dependencies = [
  "slug",
  "syntect",
  "tempfile",
+ "tokio",
  "toml",
  "tracing",
  "tracing-appender",
@@ -444,6 +458,23 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680dc087785c5230f8e8843e2e57ac7c1c90488b6a91b88caa265410568f441b"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "convert_case"
@@ -3221,13 +3252,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.10.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ color-eyre = "0.6.5"
 etcetera = "0.11.0"
 toml = "1.1.2"
 serde = { version = "1.0.228", features = [ "derive" ] }
-reqwest = { version = "0.13.3", features = [ "blocking" ] }
+reqwest = { version = "0.13.3", features = [ "blocking", "gzip" ] }
+tokio = { version = "1", features = [ "rt", "time" ] }
 clap = { version = "4.5.60", features = [ "derive" ] }
 roxmltree = "0.21.1"
 openssl = { version = "0.10", features = [ "vendored" ] }

--- a/site/docs/docs/config.md
+++ b/site/docs/docs/config.md
@@ -20,6 +20,9 @@ These settings reside at the top level.
 ### `tui_auto_update`
 Update the library on launch of the TUI. Accepts a boolean. Defaults to `true`.
 
+### `parallel_feed_updates`
+Fetch feed updates concurrently. Accepts a boolean. Defaults to `false`.
+
 ## 🪝 Hooks
 Hooks are set in the `[hooks]` table and allow you to specify shell commands to run at key lifecycle points. See [Hooks](../hooks/) for specific details.
 
@@ -27,6 +30,7 @@ Hooks are set in the `[hooks]` table and allow you to specify shell commands to 
 ```toml
 datapath = "~/.local/share/bulletty" # Specify the directory for storing the Library
 tui_auto_update = true               # Fetch new content on TUI launch
+parallel_feed_updates = true         # Enable concurrent feed updates
 
 [hooks]
 before_tui = "some-command" # Specify a shell command to run before the TUI launches

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -85,7 +85,9 @@ pub fn run_main_cli(
     match &cli.command {
         Some(Commands::List) => command_list(&cli, &config.datapath),
         Some(Commands::Add { url, category }) => command_add(&cli, url, category, &config.datapath),
-        Some(Commands::Update) => command_update(&cli, &config.datapath),
+        Some(Commands::Update) => {
+            command_update(&cli, &config.datapath, config.parallel_feed_updates)
+        }
         Some(Commands::Delete { ident }) => command_delete(&cli, ident, &config.datapath),
         Some(Commands::Dirs { subcmd }) => command_dirs(&cli, subcmd, dirs, config, config_store),
         Some(Commands::Import { opml_file }) => command_import(&cli, opml_file, &config.datapath),
@@ -130,7 +132,11 @@ fn command_add(
     Ok(())
 }
 
-fn command_update(_cli: &Cli, data_dir: &Path) -> color_eyre::Result<()> {
+fn command_update(
+    _cli: &Cli,
+    data_dir: &Path,
+    parallel_feed_updates: Option<bool>,
+) -> color_eyre::Result<()> {
     let library = FeedLibrary::new(data_dir);
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -138,6 +144,7 @@ fn command_update(_cli: &Cli, data_dir: &Path) -> color_eyre::Result<()> {
     let summary = runtime.block_on(update_feeds(
         library.feedcategories,
         data_dir,
+        parallel_feed_updates,
         |title, status| match status {
             FeedUpdateStatus::Updated => {
                 info!("Updated {title}");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,7 @@ use crate::core::config::ConfigStore;
 use crate::core::library::data::opml;
 use crate::core::library::feeditem::FeedItem;
 use crate::core::library::feedlibrary::FeedLibrary;
+use crate::core::library::updater::{FeedUpdateStatus, update_feeds};
 use crate::dirs::Directories;
 
 #[derive(Parser)]
@@ -131,18 +132,42 @@ fn command_add(
 
 fn command_update(_cli: &Cli, data_dir: &Path) -> color_eyre::Result<()> {
     let library = FeedLibrary::new(data_dir);
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    let summary = runtime.block_on(update_feeds(
+        library.feedcategories,
+        data_dir,
+        |title, status| match status {
+            FeedUpdateStatus::Updated => {
+                info!("Updated {title}");
+                println!("Updated {title}");
+            }
+            FeedUpdateStatus::Skipped => {
+                info!("Skipped {title} (updated recently)");
+                println!("Skipped {title} (updated recently)");
+            }
+            FeedUpdateStatus::Failed(update_error) => {
+                error!("Failed to update {title}: {update_error}");
+                println!("Failed {title}: {update_error}");
+            }
+        },
+    ))?;
 
-    for category in library.feedcategories.iter() {
-        for feed in category.feeds.iter() {
-            info!("Updating {}", feed.title);
-            println!("Updating {}", feed.title);
-            library
-                .data
-                .update_feed_entries(&category.title, feed, None)?;
-        }
+    println!(
+        "Update complete: {} updated, {} skipped, {} failed",
+        summary.updated, summary.skipped, summary.failed
+    );
+
+    if summary.failed == 0 {
+        Ok(())
+    } else {
+        Err(color_eyre::eyre::eyre!(
+            "{} of {} feed updates failed",
+            summary.failed,
+            summary.total
+        ))
     }
-
-    Ok(())
 }
 
 fn confirm_delete(title: &str) -> Result<bool, Error> {

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -14,6 +14,8 @@ pub struct Config {
     pub hooks: Option<AppHooks>,
     #[serde(default)]
     pub tui_auto_update: Option<bool>,
+    #[serde(default)]
+    pub parallel_feed_updates: Option<bool>,
 }
 
 pub struct ConfigStore {

--- a/src/core/feed/feedparser.rs
+++ b/src/core/feed/feedparser.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 use color_eyre::eyre::{bail, eyre};
 use html2md_bulletty::parse_html;
 use regex::Regex;
-use reqwest::blocking::Client;
+use reqwest::{Client, blocking::Client as BlockingClient};
 use roxmltree::Node;
 use slug::slugify;
 use tracing::error;
@@ -16,7 +16,7 @@ use crate::core::{
 };
 
 pub fn get_feed_with_data(url: &str) -> color_eyre::Result<(FeedItem, String)> {
-    let client = Client::builder()
+    let client = BlockingClient::builder()
         .user_agent(format!("bulletty/{}", env!("CARGO_PKG_VERSION")))
         .build()?;
 
@@ -126,12 +126,11 @@ fn parse(doc: &str, feed_url: &str) -> color_eyre::Result<FeedItem> {
     Ok(feed)
 }
 
-pub fn get_feed_entries(feed: &FeedItem) -> color_eyre::Result<Vec<FeedEntry>> {
-    let client = Client::builder()
-        .user_agent(format!("bulletty/{}", env!("CARGO_PKG_VERSION")))
-        .build()?;
-
-    let response = client.get(&feed.feed_url).send()?;
+pub async fn get_feed_entries(
+    client: &Client,
+    feed: &FeedItem,
+) -> color_eyre::Result<Vec<FeedEntry>> {
+    let response = client.get(&feed.feed_url).send().await?;
 
     if !response.status().is_success() {
         return Err(eyre!(
@@ -141,7 +140,7 @@ pub fn get_feed_entries(feed: &FeedItem) -> color_eyre::Result<Vec<FeedEntry>> {
         ));
     }
 
-    let body = response.text()?;
+    let body = response.text().await?;
     get_feed_entries_doc(&body, &feed.author)
 }
 

--- a/src/core/library/data/librarydata.rs
+++ b/src/core/library/data/librarydata.rs
@@ -164,19 +164,27 @@ impl LibraryData {
         &self,
         category: &str,
         feed: &FeedItem,
-        feedxml: Option<String>,
+        feedxml: String,
     ) -> color_eyre::Result<()> {
-        // TODO: hard coding 5 minutes for now
-        if Utc::now().signed_duration_since(feed.lastupdated) < Duration::minutes(5) {
+        if !Self::feed_needs_update(feed) {
             return Ok(());
         }
 
-        let mut feedentries = if let Some(txt) = feedxml {
-            feedparser::get_feed_entries_doc(&txt, &feed.author)
-        } else {
-            feedparser::get_feed_entries(feed)
-        }?;
+        let feedentries = feedparser::get_feed_entries_doc(&feedxml, &feed.author)?;
 
+        self.apply_feed_update(category, feed, feedentries)
+    }
+
+    pub fn feed_needs_update(feed: &FeedItem) -> bool {
+        Utc::now().signed_duration_since(feed.lastupdated) >= Duration::minutes(5)
+    }
+
+    pub fn apply_feed_update(
+        &self,
+        category: &str,
+        feed: &FeedItem,
+        mut feedentries: Vec<FeedEntry>,
+    ) -> color_eyre::Result<()> {
         feedentries.iter_mut().for_each(|e| {
             let entrypath = self
                 .path

--- a/src/core/library/feedlibrary.rs
+++ b/src/core/library/feedlibrary.rs
@@ -141,8 +141,12 @@ impl FeedLibrary {
         Ok(vec![])
     }
 
-    pub fn start_updater(&mut self) {
-        self.updater = Some(Updater::new(self.feedcategories.clone(), &self.data.path));
+    pub fn start_updater(&mut self, parallel_feed_updates: Option<bool>) {
+        self.updater = Some(Updater::new(
+            self.feedcategories.clone(),
+            &self.data.path,
+            parallel_feed_updates,
+        ));
     }
 
     pub fn bump_generation(&mut self) {

--- a/src/core/library/feedlibrary.rs
+++ b/src/core/library/feedlibrary.rs
@@ -25,7 +25,7 @@ pub struct FeedLibrary {
     pub updater: Option<Updater>,
     pub settings: UserSettings,
     pub generation: u64,
-    last_updater_completed: u16,
+    previous_updated_count: usize,
 }
 
 impl FeedLibrary {
@@ -46,7 +46,7 @@ impl FeedLibrary {
             updater: None,
             settings: UserSettings::new(data_dir).unwrap(),
             generation: 0,
-            last_updater_completed: 0,
+            previous_updated_count: 0,
         }
     }
 
@@ -61,7 +61,7 @@ impl FeedLibrary {
                 updater: None,
                 settings: UserSettings::new(temp_dir.path()).unwrap(),
                 generation: 0,
-                last_updater_completed: 0,
+                previous_updated_count: 0,
             },
             temp_dir,
         )
@@ -95,9 +95,9 @@ impl FeedLibrary {
         self.data.feed_create(&feed)?;
 
         // then update
-        // but let's only update the text is present. because of tests. maybve not the best
+        // but let's only update if the text is present. because of tests. maybe not the best
         // approach, but...
-        if text.is_some() {
+        if let Some(text) = text {
             self.data.update_feed_entries(&feed.category, &feed, text)?;
         }
 
@@ -161,37 +161,38 @@ impl FeedLibrary {
 
     pub fn update(&mut self) {
         if let Some(updater) = self.updater.as_ref() {
-            let completed = updater
-                .total_completed
+            let finished = updater.finished.load(std::sync::atomic::Ordering::Acquire);
+            let updated = updater
+                .total_updated
                 .load(std::sync::atomic::Ordering::Relaxed);
-            if completed > self.last_updater_completed {
-                self.last_updater_completed = completed;
+            if updated > self.previous_updated_count {
+                self.previous_updated_count = updated;
                 self.generation += 1;
             }
 
-            if updater.finished.load(std::sync::atomic::Ordering::Relaxed) {
+            if finished {
                 self.updater = None;
-                self.last_updater_completed = 0;
-                self.generation += 1;
+                self.previous_updated_count = 0;
             }
         }
     }
 
     pub fn get_update_status(&self) -> AppWorkStatus {
         if let Some(updater) = self.updater.as_ref() {
-            let total: f32 = self
-                .feedcategories
-                .iter()
-                .map(|cat| cat.feeds.len() as f32)
-                .sum();
+            let total = updater.total as f32;
 
             AppWorkStatus::Working(
-                1.0_f32.min(
-                    updater
-                        .total_completed
-                        .load(std::sync::atomic::Ordering::Relaxed) as f32
-                        / total,
-                ),
+                if total == 0.0 {
+                    1.0
+                } else {
+                    1.0_f32.min(
+                        updater
+                            .total_completed
+                            .load(std::sync::atomic::Ordering::Relaxed)
+                            as f32
+                            / total,
+                    )
+                },
                 updater.last_completed.lock().unwrap().to_string(),
             )
         } else {

--- a/src/core/library/updater.rs
+++ b/src/core/library/updater.rs
@@ -48,6 +48,7 @@ pub struct FeedUpdateSummary {
 pub async fn update_feeds(
     feedcategories: Vec<FeedCategory>,
     data_dir: &Path,
+    parallel_feed_updates: Option<bool>,
     mut on_complete: impl FnMut(&str, &FeedUpdateStatus),
 ) -> color_eyre::Result<FeedUpdateSummary> {
     let feeds: Vec<FeedItem> = feedcategories
@@ -73,10 +74,14 @@ pub async fn update_feeds(
         return Ok(summary);
     }
 
-    let parallelism = std::thread::available_parallelism()
-        .map(usize::from)
-        .unwrap_or(1)
-        .min(pending.len());
+    let parallelism = if matches!(parallel_feed_updates, Some(true)) {
+        std::thread::available_parallelism()
+            .map(usize::from)
+            .unwrap_or(1)
+            .min(pending.len())
+    } else {
+        1
+    };
 
     let client = Client::builder()
         .user_agent(format!("bulletty/{}", env!("CARGO_PKG_VERSION")))
@@ -150,7 +155,11 @@ pub struct Updater {
 }
 
 impl Updater {
-    pub fn new(feedcategories: Vec<FeedCategory>, data_dir: &Path) -> Self {
+    pub fn new(
+        feedcategories: Vec<FeedCategory>,
+        data_dir: &Path,
+        parallel_feed_updates: Option<bool>,
+    ) -> Self {
         let total = feedcategories
             .iter()
             .map(|category| category.feeds.len())
@@ -180,8 +189,11 @@ impl Updater {
                 }
             };
 
-            let result =
-                runtime.block_on(update_feeds(feedcategories, &data_dir, |title, status| {
+            let result = runtime.block_on(update_feeds(
+                feedcategories,
+                &data_dir,
+                parallel_feed_updates,
+                |title, status| {
                     let completed = total_completed_clone.fetch_add(1, Ordering::Relaxed) + 1;
                     if matches!(status, FeedUpdateStatus::Updated) {
                         total_updated_clone.fetch_add(1, Ordering::Relaxed);
@@ -194,7 +206,8 @@ impl Updater {
                     } else {
                         info!("{} {title}", status.label());
                     }
-                }));
+                },
+            ));
 
             if let Err(update_error) = result {
                 error!("Feed update batch failed: {update_error}");

--- a/src/core/library/updater.rs
+++ b/src/core/library/updater.rs
@@ -1,64 +1,214 @@
 use std::{
+    collections::VecDeque,
     path::{Path, PathBuf},
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, AtomicU16, Ordering::Relaxed},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     thread::{self, JoinHandle},
+    time::Duration,
 };
 
+use reqwest::Client;
+use tokio::task::JoinSet;
 use tracing::{error, info};
 
-use crate::core::library::{feedcategory::FeedCategory, feedlibrary::FeedLibrary};
+use crate::core::{
+    feed::feedparser,
+    library::{data::librarydata::LibraryData, feedcategory::FeedCategory, feeditem::FeedItem},
+};
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug)]
+pub enum FeedUpdateStatus {
+    Updated,
+    Skipped,
+    Failed(String),
+}
+
+impl FeedUpdateStatus {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Updated => "updated",
+            Self::Skipped => "skipped",
+            Self::Failed(_) => "failed",
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct FeedUpdateSummary {
+    pub total: usize,
+    pub updated: usize,
+    pub skipped: usize,
+    pub failed: usize,
+}
+
+pub async fn update_feeds(
+    feedcategories: Vec<FeedCategory>,
+    data_dir: &Path,
+    mut on_complete: impl FnMut(&str, &FeedUpdateStatus),
+) -> color_eyre::Result<FeedUpdateSummary> {
+    let feeds: Vec<FeedItem> = feedcategories
+        .into_iter()
+        .flat_map(|category| category.feeds)
+        .collect();
+    let mut summary = FeedUpdateSummary {
+        total: feeds.len(),
+        ..FeedUpdateSummary::default()
+    };
+    let mut pending = VecDeque::new();
+
+    for feed in feeds {
+        if LibraryData::feed_needs_update(&feed) {
+            pending.push_back(feed);
+        } else {
+            summary.skipped += 1;
+            on_complete(&feed.title, &FeedUpdateStatus::Skipped);
+        }
+    }
+
+    if pending.is_empty() {
+        return Ok(summary);
+    }
+
+    let parallelism = std::thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(1)
+        .min(pending.len());
+
+    let client = Client::builder()
+        .user_agent(format!("bulletty/{}", env!("CARGO_PKG_VERSION")))
+        .timeout(REQUEST_TIMEOUT)
+        .build()?;
+    let data = LibraryData::new(data_dir);
+    let mut tasks = JoinSet::new();
+    let fetch = |feed: FeedItem| {
+        let client = client.clone();
+        async move {
+            let result = feedparser::get_feed_entries(&client, &feed).await;
+            (feed, result)
+        }
+    };
+
+    // seed `parallelism` tasks
+    for feed in pending.drain(..parallelism) {
+        tasks.spawn(fetch(feed));
+    }
+
+    while let Some(task_result) = tasks.join_next().await {
+        match task_result {
+            Ok((feed, Ok(entries))) => {
+                match data.apply_feed_update(&feed.category, &feed, entries) {
+                    Ok(()) => {
+                        summary.updated += 1;
+                        on_complete(&feed.title, &FeedUpdateStatus::Updated);
+                    }
+                    Err(update_error) => {
+                        summary.failed += 1;
+                        on_complete(
+                            &feed.title,
+                            &FeedUpdateStatus::Failed(update_error.to_string()),
+                        );
+                    }
+                }
+            }
+            Ok((feed, Err(fetch_error))) => {
+                summary.failed += 1;
+                on_complete(
+                    &feed.title,
+                    &FeedUpdateStatus::Failed(fetch_error.to_string()),
+                );
+            }
+            Err(task_error) => {
+                summary.failed += 1;
+                on_complete(
+                    "unknown feed",
+                    &FeedUpdateStatus::Failed(format!("Feed update task failed: {task_error}")),
+                );
+            }
+        }
+
+        // start a new task since one has finished
+        if let Some(feed) = pending.pop_front() {
+            tasks.spawn(fetch(feed));
+        }
+    }
+
+    Ok(summary)
+}
 
 pub struct Updater {
     pub last_completed: Arc<Mutex<String>>,
-    pub total_completed: Arc<AtomicU16>,
+    pub total_completed: Arc<AtomicUsize>,
+    pub total_updated: Arc<AtomicUsize>,
     pub finished: Arc<AtomicBool>,
+    pub total: usize,
 
     _thread: Option<JoinHandle<()>>,
 }
 
 impl Updater {
     pub fn new(feedcategories: Vec<FeedCategory>, data_dir: &Path) -> Self {
-        let completed = Arc::new(Mutex::new(String::from("Working...")));
+        let total = feedcategories
+            .iter()
+            .map(|category| category.feeds.len())
+            .sum();
+        let last_completed = Arc::new(Mutex::new(String::from("Working...")));
         let finished = Arc::new(AtomicBool::new(false));
-        let total_completed = Arc::new(AtomicU16::new(0));
+        let total_completed = Arc::new(AtomicUsize::new(0));
+        let total_updated = Arc::new(AtomicUsize::new(0));
 
-        let completed_clone = Arc::clone(&completed);
+        let last_completed_clone = Arc::clone(&last_completed);
         let finished_clone = Arc::clone(&finished);
         let total_completed_clone = Arc::clone(&total_completed);
-
+        let total_updated_clone = Arc::clone(&total_updated);
         let data_dir: PathBuf = data_dir.into();
+
         let handle = Some(thread::spawn(move || {
             info!("Starting updater");
-            let library = FeedLibrary::new(&data_dir);
-
-            for category in feedcategories.iter() {
-                for feed in category.feeds.iter() {
-                    if let Err(e) = library
-                        .data
-                        .update_feed_entries(&category.title, feed, None)
-                    {
-                        error!("Something happened when updating {}: {:?}", &feed.title, e);
-                        continue;
-                    }
-
-                    info!("Updated {}", &feed.title);
-
-                    total_completed_clone.fetch_add(1, Relaxed);
-                    *completed_clone.lock().unwrap() = feed.title.clone();
+            let runtime = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => runtime,
+                Err(runtime_error) => {
+                    error!("Failed to start feed updater runtime: {runtime_error}");
+                    finished_clone.store(true, Ordering::Release);
+                    return;
                 }
-            }
+            };
 
-            finished_clone.store(true, Relaxed);
+            let result =
+                runtime.block_on(update_feeds(feedcategories, &data_dir, |title, status| {
+                    let completed = total_completed_clone.fetch_add(1, Ordering::Relaxed) + 1;
+                    if matches!(status, FeedUpdateStatus::Updated) {
+                        total_updated_clone.fetch_add(1, Ordering::Relaxed);
+                    }
+                    *last_completed_clone.lock().unwrap() =
+                        format!("{completed}/{total}: {} ({})", title, status.label());
+
+                    if let FeedUpdateStatus::Failed(update_error) = status {
+                        error!("Failed to update {title}: {update_error}");
+                    } else {
+                        info!("{} {title}", status.label());
+                    }
+                }));
+
+            if let Err(update_error) = result {
+                error!("Feed update batch failed: {update_error}");
+            }
+            finished_clone.store(true, Ordering::Release);
         }));
 
         Self {
-            last_completed: completed,
+            last_completed,
             total_completed,
-            _thread: handle,
+            total_updated,
             finished,
+            total,
+            _thread: handle,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ pub fn run() -> color_eyre::Result<()> {
         datapath: dirs.default_data().into(),
         hooks: None,
         tui_auto_update: Some(true),
+        parallel_feed_updates: Some(false),
     })?;
 
     let cli = cli::Cli::parse();

--- a/src/ui/screens/mainscreen.rs
+++ b/src/ui/screens/mainscreen.rs
@@ -168,7 +168,7 @@ impl MainScreen {
     fn force_update(&mut self) {
         let mut feed_library = self.library.borrow_mut();
         if feed_library.updater.is_none() {
-            feed_library.start_updater();
+            feed_library.start_updater(self.config.parallel_feed_updates);
         }
     }
 }
@@ -176,7 +176,9 @@ impl MainScreen {
 impl AppScreen for MainScreen {
     fn start(&mut self) {
         if !matches!(self.config.tui_auto_update, Some(false)) {
-            self.library.borrow_mut().start_updater();
+            self.library
+                .borrow_mut()
+                .start_updater(self.config.parallel_feed_updates);
         }
     }
 


### PR DESCRIPTION
This change is separated into two commits:
* Fetch feed updates concurrently in the cli and tui using a bounded tokio task set. Reuse a shared reqwest client with gzip support and request timeouts, persist completed updates sequentially, and track updated, skipped, and failed feeds separately.
* Adds a `parallel_feed_updates` option to the config file. By default, parallel feed updates are disabled. It is only enabled by setting the config option to `true`.

My personal setup is 16 feeds, and I benchmarked with a 6 core CPU. I saw a ~3x speedup on `bulletty update`.

Based on discussions in #207 