### PR TITLE
feat: hide unread counts via config

### DIFF
--- a/site/docs/docs/config.md
+++ b/site/docs/docs/config.md
@@ -23,6 +23,9 @@ Update the library on launch of the TUI. Accepts a boolean. Defaults to `true`.
 ### `parallel_feed_updates`
 Fetch feed updates concurrently. Accepts a boolean. Defaults to `true`.
 
+### `hide_unread_count`
+Hide unread article counts in the TUI. Accepts a boolean. Defaults to `false`.
+
 ## 🪝 Hooks
 Hooks are set in the `[hooks]` table and allow you to specify shell commands to run at key lifecycle points. See [Hooks](../hooks/) for specific details.
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -16,6 +16,8 @@ pub struct Config {
     pub tui_auto_update: Option<bool>,
     #[serde(default)]
     pub parallel_feed_updates: Option<bool>,
+    #[serde(default)]
+    pub hide_unread_count: Option<bool>,
 }
 
 pub struct ConfigStore {

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ pub fn run() -> color_eyre::Result<()> {
         hooks: None,
         tui_auto_update: Some(true),
         parallel_feed_updates: Some(true),
+        hide_unread_count: Some(false),
     })?;
 
     let cli = cli::Cli::parse();

--- a/src/ui/screens/mainscreen.rs
+++ b/src/ui/screens/mainscreen.rs
@@ -236,7 +236,7 @@ impl AppScreen for MainScreen {
             )
         };
 
-        let treelist = List::new(self.feedtreestate.get_items())
+        let treelist = List::new(self.feedtreestate.get_items(self.config.hide_unread_count))
             .block(treestyle)
             .highlight_style(treeselectionstyle);
 
@@ -317,9 +317,11 @@ impl AppScreen for MainScreen {
             if !statusurl.is_empty() {
                 spans.push(Span::styled(format!(" | {statusurl}"), mutedstyle));
             }
-            spans.push(Span::styled(" | ", mutedstyle));
-            spans.push(Span::styled(format!("{unread}"), unreadstyle));
-            spans.push(Span::styled(format!("/{total}"), mutedstyle));
+            if !self.config.hide_unread_count.unwrap_or(false) {
+                spans.push(Span::styled(" | ", mutedstyle));
+                spans.push(Span::styled(format!("{unread}"), unreadstyle));
+                spans.push(Span::styled(format!("/{total}"), mutedstyle));
+            }
             Line::from(spans)
         };
 

--- a/src/ui/states/feedtreestate.rs
+++ b/src/ui/states/feedtreestate.rs
@@ -87,7 +87,7 @@ impl FeedTreeState {
         }
     }
 
-    pub fn get_items(&self) -> Vec<ListItem<'_>> {
+    pub fn get_items(&self, hide_unread_count: Option<bool>) -> Vec<ListItem<'_>> {
         self.treeitems
             .iter()
             .map(|item| match item {
@@ -98,7 +98,7 @@ impl FeedTreeState {
                         .get(&(c.clone(), s.clone()))
                         .copied()
                         .unwrap_or(0);
-                    if unread > 0 {
+                    if unread > 0 && !hide_unread_count.unwrap_or(false) {
                         ListItem::new(Line::from(Span::styled(
                             format!(" \u{f09e}  ({unread}) {t}"),
                             Style::default().fg(Color::from_u32(self.theme.base[9])),
@@ -239,7 +239,7 @@ mod tests {
         let backend = TestBackend::new(30, 3);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
-            .draw(|f| f.render_widget(List::new(state.get_items()), f.area()))
+            .draw(|f| f.render_widget(List::new(state.get_items(Some(false))), f.area()))
             .unwrap();
 
         let buffer = terminal.backend().buffer();
@@ -249,8 +249,8 @@ mod tests {
         assert!(row_text(buffer, 2, 30).contains(" Read Feed"));
         assert!(!row_text(buffer, 2, 30).contains("(0)"));
 
-        // feeds with unread articles are bold and colored with the theme's
-        // unread color (base09)
+        // feeds with unread articles are colored with the theme's unread color
+        // (base09)
         let unread_cell = &buffer[(4, 1)];
         assert_eq!(unread_cell.fg, Color::from_u32(0xff0000));
 
@@ -258,6 +258,31 @@ mod tests {
         let read_cell = &buffer[(4, 2)];
         assert_eq!(read_cell.fg, Color::Reset);
         assert!(!read_cell.modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn test_hidden_unread_feed_count_has_default_style() {
+        let mut state = FeedTreeState::new();
+        state.theme.base[9] = 0xffffff;
+        state.treeitems = vec![FeedItemInfo::Item(
+            "Unread Feed".into(),
+            "Tech".into(),
+            "unread".into(),
+        )];
+        state
+            .unread_counts
+            .insert(("Tech".into(), "unread".into()), 12);
+
+        let backend = TestBackend::new(30, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| f.render_widget(List::new(state.get_items(Some(true))), f.area()))
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        assert!(row_text(buffer, 0, 30).contains(" Unread Feed"));
+        assert!(!row_text(buffer, 0, 30).contains("(12)"));
+        assert_eq!(buffer[(4, 0)].fg, Color::Reset);
     }
 
     #[test]
@@ -269,7 +294,7 @@ mod tests {
         let backend = TestBackend::new(30, 1);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
-            .draw(|f| f.render_widget(List::new(state.get_items()), f.area()))
+            .draw(|f| f.render_widget(List::new(state.get_items(None)), f.area()))
             .unwrap();
 
         assert!(row_text(terminal.backend().buffer(), 0, 30).contains("(5) Read Later"));


### PR DESCRIPTION
This change adds a config option (`hide_unread_counts`) to hide unread entry counts, which appear in two places in the TUI:

1. Before each entry in the feed list sidebar. Each feed name is prepended with its count of unread entries. Also, the feed name is a different color if that feed has unread entries. Setting `hide_unread_counts = true` in the config disables both of these behaviors.

2. The bottom bar of the TUI. This UI element features the category or feed name, the feed URL, and finally `<unread_count>/<total_entries>`. Setting `hide_unread_counts = true` in the config file also removes the unread count to total entries ratio from this bottom bar.